### PR TITLE
🐞 fix: 修复小红书解析视频直链获取

### DIFF
--- a/nonebot_plugin_resolver2/parsers/xiaohongshu.py
+++ b/nonebot_plugin_resolver2/parsers/xiaohongshu.py
@@ -81,7 +81,13 @@ class XiaoHongShuParser:
             image_list = note_data["imageList"]
             img_urls = [item["urlDefault"] for item in image_list]
         elif resource_type == "video":
-            video_url = note_data["video"]["media"]["stream"]["h264"][0]["masterUrl"]
+            stream = note_data["video"]["media"]["stream"]
+            for code in ("h264", "h265", "av1"):
+                if item := stream.get(code):
+                    video_url = item[0]["masterUrl"]
+                    break
+            if not video_url:
+                raise ParseException("小红书视频解析失败")
         else:
             raise ParseException(f"不支持的小红书链接类型: {resource_type}")
         return ParseResult(

--- a/tests/test_xhs.py
+++ b/tests/test_xhs.py
@@ -14,6 +14,7 @@ async def test_xiaohongshu():
     urls = [
         "https://www.xiaohongshu.com/discovery/item/67cdaecd000000000b0153f8?source=webshare&xhsshare=pc_web&xsec_token=ABTvdTfbnDYQGDDB-aS-b3qgxOzsq22vIUcGzW6N5j8eQ=&xsec_source=pc_share",
         "https://www.xiaohongshu.com/explore/67ebf78f000000001c0050a1?app_platform=ios&app_version=8.77&share_from_user_hidden=true&xsec_source=app_share&type=normal&xsec_token=CBUGDKBemo2y6D0IIli9maqDaaazIQjzPrk2BVRi0FqLk=&author_share=1&xhsshare=QQ&shareRedId=N0pIOUc1PDk2NzUyOTgwNjY0OTdFNktO&apptime=1744081452&share_id=00207b217b7b472588141b083af74c7a",
+        "https://www.xiaohongshu.com/discovery/item/685fd0e00000000024008b56?app_platform=android&ignoreEngage=true&app_version=8.87.6&share_from_user_hidden=true&xsec_source=app_share&type=video&xsec_token=CBc7kDk5WA32hs6hpCZ4jOhP1n0l8OeJ0kOeeUOoEHPl8%3D&author_share=1&xhsshare=QQ&shareRedId=N0w7NTk7ND82NzUyOTgwNjY0OTc4Sz9N&apptime=1751343431&share_id=c644022d3b18407d95807a10b14f0658&share_channel=qq&qq_aio_chat_type=2",
     ]
 
     async def test_parse_url(url: str) -> None:


### PR DESCRIPTION
Fixes #157

## Summary by Sourcery

Improve Xiaohongshu parser to reliably extract video URLs by iterating through multiple codec streams and raising an error if none are found.

Bug Fixes:
- Extract video direct link by checking h264, h265, and av1 streams instead of only h264.
- Raise a ParseException when no valid video stream is available.

Tests:
- Add a new test URL for an Android-shared Xiaohongshu video link.