### PR TITLE
🐛 fix: Lagrange 端部分 B 站小程序卡片不解析问题

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nonebot-plugin-resolver2"
-version = "1.11.1"
+version = "1.11.2"
 description = "NoneBot2 链接分享解析器自动解析, BV号/链接/小程序/卡片 | B站/抖音/网易云/微博/小红书/youtube/tiktok/twitter/acfun"
 authors = [{ "name" = "fllesser", "email" = "fllessive@gmail.com" }]
 urls = { Repository = "https://github.com/fllesser/nonebot-plugin-resolver2" }

--- a/src/nonebot_plugin_resolver2/matchers/preprocess.py
+++ b/src/nonebot_plugin_resolver2/matchers/preprocess.py
@@ -93,6 +93,7 @@ def extract_msg_text(event: MessageEvent, state: T_State) -> None:
     if json_seg := next((seg for seg in message if seg.type == "json"), None):
         if url := _extract_json_url(json_seg):
             state[R_EXTRACT_KEY] = url
+            return
     # 提取纯文本
     if text := message.extract_plain_text().strip():
         state[R_EXTRACT_KEY] = text

--- a/src/nonebot_plugin_resolver2/matchers/preprocess.py
+++ b/src/nonebot_plugin_resolver2/matchers/preprocess.py
@@ -10,7 +10,6 @@ from nonebot.typing import T_State
 
 R_KEYWORD_KEY: Literal["_r_keyword"] = "_r_keyword"
 R_EXTRACT_KEY: Literal["_r_extract"] = "_r_extract"
-R_EXCEPT_STR: str = "当前QQ版本不支持此应用，请升级"
 
 
 def ExtractText() -> str:
@@ -59,7 +58,7 @@ def _extract_json_url(json_seg: MessageSegment) -> str | None:
         json_seg: JSON 类型的消息段
 
     Returns:
-        Optional[str]: 提取的 URL，如果提取失败则返回 None
+        Optional[str]: 提取的 URL, 如果提取失败则返回 None
     """
     data_str: str | None = json_seg.data.get("data")
     if not data_str:
@@ -90,16 +89,13 @@ def extract_msg_text(event: MessageEvent, state: T_State) -> None:
     message = event.get_message()
     text: str | None = None
 
-    # 提取纯文本
-    # 排除部分情况下Lagrange端多出“版本不支持”纯文本消息段导致不解析
-    if (text := message.extract_plain_text().strip()) and text != R_EXCEPT_STR:
-        state[R_EXTRACT_KEY] = text
-        return
-
     # 提取json数据
     if json_seg := next((seg for seg in message if seg.type == "json"), None):
         if url := _extract_json_url(json_seg):
             state[R_EXTRACT_KEY] = url
+    # 提取纯文本
+    if text := message.extract_plain_text().strip():
+        state[R_EXTRACT_KEY] = text
 
 
 class RKeywordsRule:

--- a/src/nonebot_plugin_resolver2/matchers/preprocess.py
+++ b/src/nonebot_plugin_resolver2/matchers/preprocess.py
@@ -10,6 +10,7 @@ from nonebot.typing import T_State
 
 R_KEYWORD_KEY: Literal["_r_keyword"] = "_r_keyword"
 R_EXTRACT_KEY: Literal["_r_extract"] = "_r_extract"
+R_EXCEPT_STR: str = "当前QQ版本不支持此应用，请升级"
 
 
 def ExtractText() -> str:
@@ -89,8 +90,11 @@ def extract_msg_text(event: MessageEvent, state: T_State) -> None:
     message = event.get_message()
     text: str | None = None
 
+    
+
     # 提取纯文本
-    if text := message.extract_plain_text().strip():
+    # 排除部分情况下Lagrange端多出“版本不支持”纯文本消息段导致不解析
+    if (text := message.extract_plain_text().strip()) and text != R_EXCEPT_STR:
         state[R_EXTRACT_KEY] = text
         return
 

--- a/src/nonebot_plugin_resolver2/matchers/preprocess.py
+++ b/src/nonebot_plugin_resolver2/matchers/preprocess.py
@@ -90,8 +90,6 @@ def extract_msg_text(event: MessageEvent, state: T_State) -> None:
     message = event.get_message()
     text: str | None = None
 
-    
-
     # 提取纯文本
     # 排除部分情况下Lagrange端多出“版本不支持”纯文本消息段导致不解析
     if (text := message.extract_plain_text().strip()) and text != R_EXCEPT_STR:

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10"
 
 [[package]]
@@ -769,7 +769,7 @@ wheels = [
 
 [[package]]
 name = "nonebot-plugin-resolver2"
-version = "1.11.1"
+version = "1.11.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
使用 Lagrange 端作为无头客户端时，直接从 BiliBili 客户端进行分享的 QQ 小程序卡片会多出一个`当前QQ版本不支持此应用，请升级`的文本消息段，导致事件预处理器中`ExtractText`方法提前返回并设置`state`中`_r_extract`为文本消息而不是链接，进而导致所有从 BiliBili 客户端直接进行分享的小程序都不会进行解析

但是使用电脑或手机端进行转发后，纯文本消息段不再出现，此时插件可以正常进行解析，下面是两个消息输出`event.message`的控制台截图

不确定 Lagrange 端是否能统一这个行为，考虑先在插件这边做一个适配（

![untitled](https://github.com/user-attachments/assets/427bb8c2-098f-4660-a013-ff68a05698e6)
