### PR TITLE
fix(tiktok): use response.url instead of Location header for redirect

### DIFF
--- a/src/nonebot_plugin_resolver2/matchers/tiktok.py
+++ b/src/nonebot_plugin_resolver2/matchers/tiktok.py
@@ -23,7 +23,9 @@ async def _(searched: re.Match[str] = KeyPatternMatched()):
     if prefix == "vt" or prefix == "vm":
         async with httpx.AsyncClient(follow_redirects=True, timeout=COMMON_TIMEOUT) as client:
             response = await client.get(url)
-            url = response.headers.get("Location")
+            # 使用 response.url 获取最终重定向后的 URL
+            # 因为 follow_redirects=True 时会自动跟随重定向，最终响应没有 Location 头
+            url = str(response.url)
 
     pub_prefix = f"{NICKNAME}解析 | TikTok - "
     if not url:


### PR DESCRIPTION
## Problem

When parsing TikTok short URLs (vt.tiktok.com or vm.tiktok.com), the plugin always returns 'short URL redirect failed' error, even though the HTTP request successfully returns 200 OK.

## Root Cause

In \matchers/tiktok.py\, when \ollow_redirects=True\ is set:

\\\python
async with httpx.AsyncClient(follow_redirects=True, timeout=COMMON_TIMEOUT) as client:
    response = await client.get(url)
    url = response.headers.get('Location')  # Returns None!
\\\

The httpx client automatically follows all redirects to the final page. Since the final response is not a redirect, it doesn't have a \Location\ header, so \esponse.headers.get('Location')\ returns \None\.

## Solution

Use \str(response.url)\ to get the final redirected URL instead of reading the \Location\ header.

## Testing

Tested with TikTok short URL: \https://vt.tiktok.com/ZSPDEaEjt/\

Before fix: 'short URL redirect failed'
After fix: Successfully parsed and downloaded the video