### PR TITLE
feat(render):  完成 htmlrender 渲染模板

### DIFF
--- a/src/nonebot_plugin_parser/parsers/bilibili/__init__.py
+++ b/src/nonebot_plugin_parser/parsers/bilibili/__init__.py
@@ -20,7 +20,7 @@ from ..base import (
     handle,
     pconfig,
 )
-from ..data import Platform, ImageContent, MediaContent, ParseResult
+from ..data import Platform, ParseResult, ImageContent, MediaContent
 from ..cookie import ck2dict
 
 # 选择客户端

--- a/src/nonebot_plugin_parser/parsers/bilibili/__init__.py
+++ b/src/nonebot_plugin_parser/parsers/bilibili/__init__.py
@@ -168,9 +168,9 @@ class BilibiliParser(BaseParser):
             return await self._parse_bilibli_api_opus(dynamic.turn_to_opus())
 
         dynamic_info = convert(await dynamic.get_info(), DynamicWrapper).item
-        return await self.parse_dynamic_info(dynamic_info)
+        return await self._parse_dynamic_info(dynamic_info)
 
-    async def parse_dynamic_info(self, dynamic_info: DynamicInfo):
+    async def _parse_dynamic_info(self, dynamic_info: DynamicInfo):
         if dynamic_info.is_video():
             if (major := dynamic_info.modules.major) and (archive := major.archive):
                 return await self.parse_video(bvid=archive.bvid)
@@ -182,7 +182,7 @@ class BilibiliParser(BaseParser):
 
         repost = None
         if dynamic_info.type == "DYNAMIC_TYPE_FORWARD" and dynamic_info.orig is not None:
-            repost = await self.parse_dynamic_info(dynamic_info.orig)
+            repost = await self._parse_dynamic_info(dynamic_info.orig)
 
         return self.result(
             title=dynamic_info.title,

--- a/src/nonebot_plugin_parser/parsers/bilibili/__init__.py
+++ b/src/nonebot_plugin_parser/parsers/bilibili/__init__.py
@@ -20,7 +20,7 @@ from ..base import (
     handle,
     pconfig,
 )
-from ..data import Platform, ParseResult, ImageContent, MediaContent
+from ..data import Platform, ImageContent, MediaContent
 from ..cookie import ck2dict
 
 # 选择客户端
@@ -176,26 +176,25 @@ class BilibiliParser(BaseParser):
             contents.append(ImageContent(img_task))
 
         # 转发动态：递归解析原始动态
-        repost: ParseResult | None = None
+        repost = None
         if dynamic_info.type == "DYNAMIC_TYPE_FORWARD" and dynamic_info.orig:
             orig = dynamic_info.orig
             orig_author = self.create_author(orig.name, orig.avatar)
-            orig_contents: list[MediaContent] = []
-            for image_url in orig.image_urls:
-                img_task = self.downloader.download_img(image_url, ext_headers=self.headers)
-                orig_contents.append(ImageContent(img_task))
 
-            repost = self.result(
-                title=orig.title,
-                text=orig.text,
-                timestamp=orig.timestamp,
-                author=orig_author,
-                contents=orig_contents,
-                extra={
-                    "is_video": bool(orig.cover_url),
-                    "duration": orig.duration,
-                },
-            )
+            # 视频动态
+            if orig.is_video():
+                if (major := orig.modules.major) and (archive := major.archive):
+                    repost = await self.parse_video(bvid=archive.bvid)
+            else:
+                orig_contents: list[MediaContent] = []
+                orig_contents.extend(self.create_image_contents(orig.image_urls))
+                repost = self.result(
+                    title=orig.title,
+                    text=orig.text,
+                    timestamp=orig.timestamp,
+                    author=orig_author,
+                    contents=orig_contents,
+                )
 
         return self.result(
             title=dynamic_info.title,
@@ -204,11 +203,7 @@ class BilibiliParser(BaseParser):
             author=author,
             contents=contents,
             repost=repost,
-            extra={
-                "content_type": "动态",
-                "is_video": bool(dynamic_info.cover_url),
-                "duration": dynamic_info.duration,
-            },
+            extra={"content_type": "动态"},
         )
 
     async def parse_opus_by_id(self, opus_id: int):

--- a/src/nonebot_plugin_parser/parsers/bilibili/__init__.py
+++ b/src/nonebot_plugin_parser/parsers/bilibili/__init__.py
@@ -171,19 +171,9 @@ class BilibiliParser(BaseParser):
 
         # 下载图片 / 视频封面
         contents: list[MediaContent] = []
-        if dynamic_info.cover_url:
-            # 视频类动态，用 VideoContent 以显示播放按钮
-            contents.append(
-                self.create_video_content(
-                    self.downloader.download_img(dynamic_info.cover_url, ext_headers=self.headers),
-                    cover_url=dynamic_info.cover_url,
-                    duration=dynamic_info.duration,
-                )
-            )
-        else:
-            for image_url in dynamic_info.image_urls:
-                img_task = self.downloader.download_img(image_url, ext_headers=self.headers)
-                contents.append(ImageContent(img_task))
+        for image_url in dynamic_info.image_urls:
+            img_task = self.downloader.download_img(image_url, ext_headers=self.headers)
+            contents.append(ImageContent(img_task))
 
         # 转发动态：递归解析原始动态
         repost: ParseResult | None = None
@@ -191,20 +181,9 @@ class BilibiliParser(BaseParser):
             orig = dynamic_info.orig
             orig_author = self.create_author(orig.name, orig.avatar)
             orig_contents: list[MediaContent] = []
-
-            if orig.cover_url:
-                # 原始动态是视频，用 VideoContent 以显示播放按钮
-                orig_contents.append(
-                    self.create_video_content(
-                        self.downloader.download_img(orig.cover_url, ext_headers=self.headers),
-                        cover_url=orig.cover_url,
-                        duration=orig.duration,
-                    )
-                )
-            else:
-                for image_url in orig.image_urls:
-                    img_task = self.downloader.download_img(image_url, ext_headers=self.headers)
-                    orig_contents.append(ImageContent(img_task))
+            for image_url in orig.image_urls:
+                img_task = self.downloader.download_img(image_url, ext_headers=self.headers)
+                orig_contents.append(ImageContent(img_task))
 
             repost = self.result(
                 title=orig.title,
@@ -212,6 +191,10 @@ class BilibiliParser(BaseParser):
                 timestamp=orig.timestamp,
                 author=orig_author,
                 contents=orig_contents,
+                extra={
+                    "is_video": bool(orig.cover_url),
+                    "duration": orig.duration,
+                },
             )
 
         return self.result(
@@ -221,7 +204,11 @@ class BilibiliParser(BaseParser):
             author=author,
             contents=contents,
             repost=repost,
-            extra={"content_type": "动态"},
+            extra={
+                "content_type": "动态",
+                "is_video": bool(dynamic_info.cover_url),
+                "duration": dynamic_info.duration,
+            },
         )
 
     async def parse_opus_by_id(self, opus_id: int):

--- a/src/nonebot_plugin_parser/parsers/bilibili/__init__.py
+++ b/src/nonebot_plugin_parser/parsers/bilibili/__init__.py
@@ -181,9 +181,8 @@ class BilibiliParser(BaseParser):
         contents.extend(self.create_image_contents(dynamic_info.image_urls))
 
         repost = None
-        if dynamic_info.type == "DYNAMIC_TYPE_FORWARD" and dynamic_info.orig:
-            orig = dynamic_info.orig
-            repost = await self.parse_dynamic_info(orig)
+        if dynamic_info.type == "DYNAMIC_TYPE_FORWARD" and dynamic_info.orig is not None:
+            repost = await self.parse_dynamic_info(dynamic_info.orig)
 
         return self.result(
             title=dynamic_info.title,

--- a/src/nonebot_plugin_parser/parsers/bilibili/__init__.py
+++ b/src/nonebot_plugin_parser/parsers/bilibili/__init__.py
@@ -22,6 +22,7 @@ from ..base import (
 )
 from ..data import Platform, ImageContent, MediaContent
 from ..cookie import ck2dict
+from .dynamic import DynamicInfo
 
 # 选择客户端
 select_client("curl_cffi")
@@ -160,41 +161,29 @@ class BilibiliParser(BaseParser):
         """解析动态或图文"""
         from bilibili_api.dynamic import Dynamic
 
-        from .dynamic import DynamicData
+        from .dynamic import DynamicWrapper
 
         dynamic = Dynamic(dynamic_id, await self.credential)
         if await dynamic.is_article():
             return await self._parse_bilibli_api_opus(dynamic.turn_to_opus())
 
-        dynamic_info = convert(await dynamic.get_info(), DynamicData).item
+        dynamic_info = convert(await dynamic.get_info(), DynamicWrapper).item
+        return await self.parse_dynamic_info(dynamic_info)
+
+    async def parse_dynamic_info(self, dynamic_info: DynamicInfo):
+        if dynamic_info.is_video():
+            if (major := dynamic_info.modules.major) and (archive := major.archive):
+                return await self.parse_video(bvid=archive.bvid)
+
+        # 下载图片
         author = self.create_author(dynamic_info.name, dynamic_info.avatar)
-
-        # 下载图片 / 视频封面
         contents: list[MediaContent] = []
-        for image_url in dynamic_info.image_urls:
-            img_task = self.downloader.download_img(image_url, ext_headers=self.headers)
-            contents.append(ImageContent(img_task))
+        contents.extend(self.create_image_contents(dynamic_info.image_urls))
 
-        # 转发动态：递归解析原始动态
         repost = None
         if dynamic_info.type == "DYNAMIC_TYPE_FORWARD" and dynamic_info.orig:
             orig = dynamic_info.orig
-            orig_author = self.create_author(orig.name, orig.avatar)
-
-            # 视频动态
-            if orig.is_video():
-                if (major := orig.modules.major) and (archive := major.archive):
-                    repost = await self.parse_video(bvid=archive.bvid)
-            else:
-                orig_contents: list[MediaContent] = []
-                orig_contents.extend(self.create_image_contents(orig.image_urls))
-                repost = self.result(
-                    title=orig.title,
-                    text=orig.text,
-                    timestamp=orig.timestamp,
-                    author=orig_author,
-                    contents=orig_contents,
-                )
+            repost = await self.parse_dynamic_info(orig)
 
         return self.result(
             title=dynamic_info.title,

--- a/src/nonebot_plugin_parser/parsers/bilibili/__init__.py
+++ b/src/nonebot_plugin_parser/parsers/bilibili/__init__.py
@@ -173,7 +173,10 @@ class BilibiliParser(BaseParser):
     async def _parse_dynamic_info(self, dynamic_info: DynamicInfo):
         if dynamic_info.is_video():
             if (major := dynamic_info.modules.major) and (archive := major.archive):
-                return await self.parse_video(bvid=archive.bvid)
+                result = await self.parse_video(bvid=archive.bvid)
+                result.text = dynamic_info.text
+                result.extra["content_type"] = "动态"
+                return result
 
         # 下载图片
         author = self.create_author(dynamic_info.name, dynamic_info.avatar)

--- a/src/nonebot_plugin_parser/parsers/bilibili/__init__.py
+++ b/src/nonebot_plugin_parser/parsers/bilibili/__init__.py
@@ -20,7 +20,7 @@ from ..base import (
     handle,
     pconfig,
 )
-from ..data import Platform, ImageContent, MediaContent
+from ..data import Platform, ImageContent, MediaContent, ParseResult
 from ..cookie import ck2dict
 
 # 选择客户端
@@ -169,11 +169,50 @@ class BilibiliParser(BaseParser):
         dynamic_info = convert(await dynamic.get_info(), DynamicData).item
         author = self.create_author(dynamic_info.name, dynamic_info.avatar)
 
-        # 下载图片
+        # 下载图片 / 视频封面
         contents: list[MediaContent] = []
-        for image_url in dynamic_info.image_urls:
-            img_task = self.downloader.download_img(image_url, ext_headers=self.headers)
-            contents.append(ImageContent(img_task))
+        if dynamic_info.cover_url:
+            # 视频类动态，用 VideoContent 以显示播放按钮
+            contents.append(
+                self.create_video_content(
+                    self.downloader.download_img(dynamic_info.cover_url, ext_headers=self.headers),
+                    cover_url=dynamic_info.cover_url,
+                    duration=dynamic_info.duration,
+                )
+            )
+        else:
+            for image_url in dynamic_info.image_urls:
+                img_task = self.downloader.download_img(image_url, ext_headers=self.headers)
+                contents.append(ImageContent(img_task))
+
+        # 转发动态：递归解析原始动态
+        repost: ParseResult | None = None
+        if dynamic_info.type == "DYNAMIC_TYPE_FORWARD" and dynamic_info.orig:
+            orig = dynamic_info.orig
+            orig_author = self.create_author(orig.name, orig.avatar)
+            orig_contents: list[MediaContent] = []
+
+            if orig.cover_url:
+                # 原始动态是视频，用 VideoContent 以显示播放按钮
+                orig_contents.append(
+                    self.create_video_content(
+                        self.downloader.download_img(orig.cover_url, ext_headers=self.headers),
+                        cover_url=orig.cover_url,
+                        duration=orig.duration,
+                    )
+                )
+            else:
+                for image_url in orig.image_urls:
+                    img_task = self.downloader.download_img(image_url, ext_headers=self.headers)
+                    orig_contents.append(ImageContent(img_task))
+
+            repost = self.result(
+                title=orig.title,
+                text=orig.text,
+                timestamp=orig.timestamp,
+                author=orig_author,
+                contents=orig_contents,
+            )
 
         return self.result(
             title=dynamic_info.title,
@@ -181,6 +220,8 @@ class BilibiliParser(BaseParser):
             timestamp=dynamic_info.timestamp,
             author=author,
             contents=contents,
+            repost=repost,
+            extra={"content_type": "动态"},
         )
 
     async def parse_opus_by_id(self, opus_id: int):

--- a/src/nonebot_plugin_parser/parsers/bilibili/dynamic.py
+++ b/src/nonebot_plugin_parser/parsers/bilibili/dynamic.py
@@ -234,7 +234,5 @@ class DynamicInfo(Struct):
         return major is not None and major.archive is not None
 
 
-class DynamicData(Struct):
-    """动态项目"""
-
+class DynamicWrapper(Struct):
     item: DynamicInfo

--- a/src/nonebot_plugin_parser/parsers/bilibili/dynamic.py
+++ b/src/nonebot_plugin_parser/parsers/bilibili/dynamic.py
@@ -1,5 +1,4 @@
 from typing import Any
-from functools import cached_property
 
 from msgspec import Struct, convert
 
@@ -135,6 +134,8 @@ class DynamicModule(Struct):
     module_dynamic: dict[str, Any] | None = None
     module_stat: dict[str, Any] | None = None
 
+    _cached_major: DynamicMajor | None = None
+
     @property
     def author_name(self) -> str:
         """获取作者名称"""
@@ -160,12 +161,14 @@ class DynamicModule(Struct):
             return self.module_dynamic
         return None
 
-    @cached_property
+    @property
     def major(self) -> DynamicMajor | None:
         """获取缓存的 DynamicMajor 实例"""
-        major_info = self._major_info
-        if major_info:
-            return convert(major_info, DynamicMajor)
+        if self._cached_major is None:
+            major_info = self._major_info
+            if major_info:
+                self._cached_major = convert(major_info, DynamicMajor)
+        return self._cached_major
 
     @property
     def desc_text(self) -> str | None:

--- a/src/nonebot_plugin_parser/parsers/bilibili/dynamic.py
+++ b/src/nonebot_plugin_parser/parsers/bilibili/dynamic.py
@@ -1,6 +1,6 @@
 from typing import Any
 
-from msgspec import Struct, convert
+from msgspec import Struct, field, convert
 
 
 class AuthorInfo(Struct):
@@ -134,6 +134,8 @@ class DynamicModule(Struct):
     module_dynamic: dict[str, Any] | None = None
     module_stat: dict[str, Any] | None = None
 
+    _cached_major: DynamicMajor | None = field(default=None)
+
     @property
     def author_name(self) -> str:
         """获取作者名称"""
@@ -150,7 +152,7 @@ class DynamicModule(Struct):
         return self.module_author.pub_ts
 
     @property
-    def major_info(self) -> dict[str, Any] | None:
+    def _major_info(self) -> dict[str, Any] | None:
         """获取主要内容信息"""
         if self.module_dynamic:
             if major := self.module_dynamic.get("major"):
@@ -158,6 +160,15 @@ class DynamicModule(Struct):
             # 转发类型动态没有 major
             return self.module_dynamic
         return None
+
+    @property
+    def major(self) -> DynamicMajor | None:
+        """获取缓存的 DynamicMajor 实例"""
+        if self._cached_major is None:
+            major_info = self._major_info
+            if major_info:
+                self._cached_major = convert(major_info, DynamicMajor)
+        return self._cached_major
 
     @property
     def desc_text(self) -> str | None:
@@ -197,11 +208,8 @@ class DynamicInfo(Struct):
     @property
     def title(self) -> str | None:
         """获取标题"""
-        major_info = self.modules.major_info
-        if major_info:
-            major = convert(major_info, DynamicMajor)
+        if major := self.modules.major:
             return major.title
-        return None
 
     @property
     def text(self) -> str | None:
@@ -210,38 +218,20 @@ class DynamicInfo(Struct):
         if desc_text := self.modules.desc_text:
             return desc_text
         # 回退到 major 的文字（图文摘要、视频简介等）
-        major_info = self.modules.major_info
-        if major_info:
-            major = convert(major_info, DynamicMajor)
+        if major := self.modules.major:
             return major.text
-        return None
 
     @property
     def image_urls(self) -> list[str]:
         """获取图片URL列表"""
-        major_info = self.modules.major_info
-        if major_info:
-            major = convert(major_info, DynamicMajor)
+        if major := self.modules.major:
             return major.image_urls
         return []
 
-    @property
-    def cover_url(self) -> str | None:
-        """获取封面URL"""
-        major_info = self.modules.major_info
-        if major_info:
-            major = convert(major_info, DynamicMajor)
-            return major.cover_url
-        return None
-
-    @property
-    def duration(self) -> float:
-        """获取视频时长（秒）"""
-        major_info = self.modules.major_info
-        if major_info:
-            major = convert(major_info, DynamicMajor)
-            return major.duration
-        return 0.0
+    def is_video(self) -> bool:
+        """判断是否为视频动态"""
+        major = self.modules.major
+        return major is not None and major.archive is not None
 
 
 class DynamicData(Struct):

--- a/src/nonebot_plugin_parser/parsers/bilibili/dynamic.py
+++ b/src/nonebot_plugin_parser/parsers/bilibili/dynamic.py
@@ -1,6 +1,7 @@
 from typing import Any
+from functools import cached_property
 
-from msgspec import Struct, field, convert
+from msgspec import Struct, convert
 
 
 class AuthorInfo(Struct):
@@ -134,8 +135,6 @@ class DynamicModule(Struct):
     module_dynamic: dict[str, Any] | None = None
     module_stat: dict[str, Any] | None = None
 
-    _cached_major: DynamicMajor | None = field(default=None)
-
     @property
     def author_name(self) -> str:
         """获取作者名称"""
@@ -161,14 +160,12 @@ class DynamicModule(Struct):
             return self.module_dynamic
         return None
 
-    @property
+    @cached_property
     def major(self) -> DynamicMajor | None:
         """获取缓存的 DynamicMajor 实例"""
-        if self._cached_major is None:
-            major_info = self._major_info
-            if major_info:
-                self._cached_major = convert(major_info, DynamicMajor)
-        return self._cached_major
+        major_info = self._major_info
+        if major_info:
+            return convert(major_info, DynamicMajor)
 
     @property
     def desc_text(self) -> str | None:

--- a/src/nonebot_plugin_parser/parsers/bilibili/dynamic.py
+++ b/src/nonebot_plugin_parser/parsers/bilibili/dynamic.py
@@ -26,10 +26,25 @@ class VideoArchive(Struct):
     title: str
     desc: str
     cover: str
-    # duration_text: str
+    duration_text: str = ""
     # jump_url: str
     # stat: dict[str, str]
     # badge: dict[str, Any] | None = None
+
+    @property
+    def duration_seconds(self) -> float:
+        """将 duration_text（如 '3:42'）解析为秒数"""
+        if not self.duration_text:
+            return 0.0
+        parts = self.duration_text.split(":")
+        try:
+            if len(parts) == 2:
+                return int(parts[0]) * 60 + int(parts[1])
+            elif len(parts) == 3:
+                return int(parts[0]) * 3600 + int(parts[1]) * 60 + int(parts[2])
+        except ValueError:
+            pass
+        return 0.0
 
 
 class OpusImage(Struct):
@@ -104,6 +119,13 @@ class DynamicMajor(Struct):
             return self.archive.cover
         return None
 
+    @property
+    def duration(self) -> float:
+        """获取视频时长（秒）"""
+        if self.type == "MAJOR_TYPE_ARCHIVE" and self.archive:
+            return self.archive.duration_seconds
+        return 0.0
+
 
 class DynamicModule(Struct):
     """动态模块"""
@@ -137,6 +159,15 @@ class DynamicModule(Struct):
             return self.module_dynamic
         return None
 
+    @property
+    def desc_text(self) -> str | None:
+        """获取动态自身的文字描述（非 major 内容的文字）"""
+        if self.module_dynamic:
+            desc = self.module_dynamic.get("desc")
+            if desc and isinstance(desc, dict):
+                return desc.get("text")
+        return None
+
 
 class DynamicInfo(Struct):
     """动态信息"""
@@ -146,6 +177,7 @@ class DynamicInfo(Struct):
     visible: bool
     modules: DynamicModule
     basic: dict[str, Any] | None = None
+    orig: "DynamicInfo | None" = None
 
     @property
     def name(self) -> str:
@@ -173,7 +205,11 @@ class DynamicInfo(Struct):
 
     @property
     def text(self) -> str | None:
-        """获取文本内容"""
+        """获取文本内容（优先取动态自身文字，回退到 major 的文字）"""
+        # 优先取动态自身描述（如发视频时附带的文字）
+        if desc_text := self.modules.desc_text:
+            return desc_text
+        # 回退到 major 的文字（图文摘要、视频简介等）
         major_info = self.modules.major_info
         if major_info:
             major = convert(major_info, DynamicMajor)
@@ -197,6 +233,15 @@ class DynamicInfo(Struct):
             major = convert(major_info, DynamicMajor)
             return major.cover_url
         return None
+
+    @property
+    def duration(self) -> float:
+        """获取视频时长（秒）"""
+        major_info = self.modules.major_info
+        if major_info:
+            major = convert(major_info, DynamicMajor)
+            return major.duration
+        return 0.0
 
 
 class DynamicData(Struct):

--- a/src/nonebot_plugin_parser/parsers/data.py
+++ b/src/nonebot_plugin_parser/parsers/data.py
@@ -156,7 +156,7 @@ class Author:
         return repr + ")"
 
 
-@dataclass(repr=False, slots=True)
+@dataclass(repr=False)
 class ParseResult:
     """完整的解析结果"""
 

--- a/src/nonebot_plugin_parser/parsers/data.py
+++ b/src/nonebot_plugin_parser/parsers/data.py
@@ -26,6 +26,11 @@ class MediaContent:
         self.path_task = await self.path_task
         return self.path_task
 
+    @property
+    def path_uri(self):
+        if isinstance(self.path_task, Path):
+            return self.path_task.as_uri()
+
     def __repr__(self) -> str:
         prefix = self.__class__.__name__
         return f"{prefix}({repr_path_task(self.path_task)})"
@@ -54,6 +59,11 @@ class VideoContent(MediaContent):
             return self.cover
         self.cover = await self.cover
         return self.cover
+
+    @property
+    def cover_path_uri(self):
+        if isinstance(self.cover, Path):
+            return self.cover.as_uri()
 
     @property
     def display_duration(self) -> str:
@@ -130,6 +140,11 @@ class Author:
             return self.avatar
         self.avatar = await self.avatar
         return self.avatar
+
+    @property
+    def avatar_path_uri(self):
+        if isinstance(self.avatar, Path):
+            return self.avatar.as_uri()
 
     def __repr__(self) -> str:
         repr = f"Author(name={self.name}"
@@ -219,6 +234,31 @@ class ParseResult:
     def formartted_datetime(self, fmt: str = "%Y-%m-%d %H:%M:%S") -> str | None:
         """格式化时间戳"""
         return datetime.fromtimestamp(self.timestamp).strftime(fmt) if self.timestamp is not None else None
+
+    async def ensure_img_ready(self) -> None:
+        if author := self.author:
+            await author.get_avatar_path()
+
+        for cont in self.contents:
+            if isinstance(cont, VideoContent):
+                await cont.get_cover_path()
+            else:
+                await cont.get_path()
+
+    @property
+    def content_type(self) -> str | None:
+        """获取内容类型 (允许解析器通过 extra 显式指定)"""
+        content_type = self.extra.get("content_type")
+        if content_type is None:
+            if self.video_contents:
+                content_type = "视频"
+            elif self.graphics_contents:
+                content_type = "图文"
+            elif self.img_contents:
+                content_type = "动态"
+            elif self.repost:
+                content_type = "动态"
+        return content_type
 
     def __repr__(self) -> str:
         return (

--- a/src/nonebot_plugin_parser/parsers/data.py
+++ b/src/nonebot_plugin_parser/parsers/data.py
@@ -4,6 +4,8 @@ from pathlib import Path
 from datetime import datetime
 from dataclasses import field, dataclass
 
+from ..utils import fmt_duration
+
 
 def repr_path_task(path_task: Path | Task[Path]) -> str:
     if isinstance(path_task, Path):
@@ -53,9 +55,7 @@ class VideoContent(MediaContent):
 
     @property
     def display_duration(self) -> str:
-        minutes = int(self.duration) // 60
-        seconds = int(self.duration) % 60
-        return f"时长: {minutes}:{seconds:02d}"
+        return f"时长: {fmt_duration(self.duration)}"
 
     def __repr__(self) -> str:
         repr = f"VideoContent({repr_path_task(self.path_task)}"

--- a/src/nonebot_plugin_parser/parsers/data.py
+++ b/src/nonebot_plugin_parser/parsers/data.py
@@ -251,8 +251,7 @@ class ParseResult:
     @property
     def content_type(self) -> str | None:
         """获取内容类型 (允许解析器通过 extra 显式指定)"""
-        if content_type := self.extra.get("content_type"):
-            return content_type
+        content_type = self.extra.get("content_type")
 
         if content_type is None:
             if self.video_contents:
@@ -263,6 +262,8 @@ class ParseResult:
                 return "动态"
             elif self.repost:
                 return "动态"
+
+        return content_type
 
     def __repr__(self) -> str:
         return (

--- a/src/nonebot_plugin_parser/parsers/data.py
+++ b/src/nonebot_plugin_parser/parsers/data.py
@@ -235,7 +235,7 @@ class ParseResult:
         """格式化时间戳"""
         return datetime.fromtimestamp(self.timestamp).strftime(fmt) if self.timestamp is not None else None
 
-    async def ensure_img_ready(self) -> None:
+    async def ensure_imgs_ready(self) -> None:
         if author := self.author:
             await author.get_avatar_path()
 
@@ -246,7 +246,7 @@ class ParseResult:
                 await cont.get_path()
 
         if self.repost is not None:
-            await self.repost.ensure_img_ready()
+            await self.repost.ensure_imgs_ready()
 
     @property
     def content_type(self) -> str | None:

--- a/src/nonebot_plugin_parser/parsers/data.py
+++ b/src/nonebot_plugin_parser/parsers/data.py
@@ -4,6 +4,7 @@ from typing import Any, TypedDict
 from asyncio import Task
 from pathlib import Path
 from datetime import datetime
+from functools import cached_property
 from dataclasses import field, dataclass
 
 from ..utils import fmt_duration
@@ -202,23 +203,23 @@ class ParseResult:
     def extra_info(self) -> str | None:
         return self.extra.get("info")
 
-    @property
+    @cached_property
     def video_contents(self) -> list[VideoContent]:
         return [cont for cont in self.contents if isinstance(cont, VideoContent)]
 
-    @property
+    @cached_property
     def img_contents(self) -> list[ImageContent]:
         return [cont for cont in self.contents if isinstance(cont, ImageContent)]
 
-    @property
+    @cached_property
     def audio_contents(self) -> list[AudioContent]:
         return [cont for cont in self.contents if isinstance(cont, AudioContent)]
 
-    @property
+    @cached_property
     def dynamic_contents(self) -> list[DynamicContent]:
         return [cont for cont in self.contents if isinstance(cont, DynamicContent)]
 
-    @property
+    @cached_property
     def graphics_contents(self) -> list[GraphicsContent]:
         return [cont for cont in self.contents if isinstance(cont, GraphicsContent)]
 

--- a/src/nonebot_plugin_parser/parsers/data.py
+++ b/src/nonebot_plugin_parser/parsers/data.py
@@ -251,17 +251,18 @@ class ParseResult:
     @property
     def content_type(self) -> str | None:
         """获取内容类型 (允许解析器通过 extra 显式指定)"""
-        content_type = self.extra.get("content_type")
+        if content_type := self.extra.get("content_type"):
+            return content_type
+
         if content_type is None:
             if self.video_contents:
-                content_type = "视频"
+                return "视频"
             elif self.graphics_contents:
-                content_type = "图文"
+                return "图文"
             elif self.img_contents:
-                content_type = "动态"
+                return "动态"
             elif self.repost:
-                content_type = "动态"
-        return content_type
+                return "动态"
 
     def __repr__(self) -> str:
         return (

--- a/src/nonebot_plugin_parser/parsers/data.py
+++ b/src/nonebot_plugin_parser/parsers/data.py
@@ -245,6 +245,9 @@ class ParseResult:
             else:
                 await cont.get_path()
 
+        if self.repost is not None:
+            await self.repost.ensure_img_ready()
+
     @property
     def content_type(self) -> str | None:
         """获取内容类型 (允许解析器通过 extra 显式指定)"""

--- a/src/nonebot_plugin_parser/renders/common.py
+++ b/src/nonebot_plugin_parser/renders/common.py
@@ -21,7 +21,10 @@ PILImageDraw = ImageDraw.ImageDraw
 
 try:
     import emosvg
-except (ImportError, OSError):
+except ImportError:
+    emosvg = None
+except OSError:
+    logger.error("未安装 cairo, 无法使用 emosvg 渲染 emoji")
     emosvg = None
 
 

--- a/src/nonebot_plugin_parser/renders/common.py
+++ b/src/nonebot_plugin_parser/renders/common.py
@@ -11,6 +11,7 @@ from nonebot import logger
 from apilmoji import Apilmoji, EmojiCDNSource
 from apilmoji.core import get_font_height
 
+from . import resources
 from .base import ParseResult, ImageRenderer
 from ..config import pconfig
 from ..parsers import GraphicsContent
@@ -126,11 +127,7 @@ class CommonRenderer(ImageRenderer):
     REPOST_BG_COLOR: ClassVar[Color] = (247, 247, 247)
     REPOST_BORDER_COLOR: ClassVar[Color] = (230, 230, 230)
 
-    # 资源路径
-    RESOURCES_DIR: ClassVar[Path] = Path(__file__).parent / "resources"
-    DEFAULT_FONT_PATH: ClassVar[Path] = RESOURCES_DIR / "HYSongYunLangHeiW.ttf"
-    DEFAULT_AVATAR_PATH: ClassVar[Path] = RESOURCES_DIR / "avatar.png"
-    DEFAULT_VIDEO_BUTTON_PATH: ClassVar[Path] = RESOURCES_DIR / "play.png"
+    # apilmoji emoji 源
     EMOJI_SOURCE: ClassVar[EmojiCDNSource] = EmojiCDNSource(
         base_url=pconfig.emoji_cdn,
         style=pconfig.emoji_style,
@@ -147,7 +144,7 @@ class CommonRenderer(ImageRenderer):
 
     @classmethod
     def _load_fonts(cls):
-        font_path = pconfig.custom_font or cls.DEFAULT_FONT_PATH
+        font_path = pconfig.custom_font or resources.DEFAULT_FONT_PATH
         cls.fontset = FontSet.new(font_path)
         logger.success(f"加载字体「{font_path.name}」成功")
 
@@ -157,7 +154,7 @@ class CommonRenderer(ImageRenderer):
 
         cls.platform_logos: dict[str, PILImage] = {}
         for platform_name in PlatformEnum:
-            logo_path = cls.RESOURCES_DIR / f"{platform_name}.png"
+            logo_path = resources.RESOURCES_DIR / f"{platform_name}.png"
             if logo_path.exists():
                 with Image.open(logo_path) as img:
                     cls.platform_logos[str(platform_name)] = img.convert("RGBA")
@@ -166,17 +163,17 @@ class CommonRenderer(ImageRenderer):
     @classmethod
     def _load_other_resources(cls):
         # avatar
-        with Image.open(cls.DEFAULT_AVATAR_PATH) as img:
+        with Image.open(resources.DEFAULT_AVATAR_PATH) as img:
             cls.avatar_image: PILImage = img.convert("RGBA").resize((cls.AVATAR_SIZE, cls.AVATAR_SIZE))
-        logger.debug(f"加载头像「{cls.DEFAULT_AVATAR_PATH.name}」成功")
+        logger.debug(f"加载头像「{resources.DEFAULT_AVATAR_PATH.name}」成功")
 
         # video button
-        with Image.open(cls.DEFAULT_VIDEO_BUTTON_PATH) as img:
+        with Image.open(resources.DEFAULT_VIDEO_BUTTON_PATH) as img:
             cls.video_button_image: PILImage = img.convert("RGBA").resize((100, 100))
         alpha = cls.video_button_image.split()[-1]
         alpha = alpha.point(lambda x: int(x * 0.5))
         cls.video_button_image.putalpha(alpha)
-        logger.debug(f"加载视频按钮「{cls.DEFAULT_VIDEO_BUTTON_PATH.name}」成功")
+        logger.debug(f"加载视频按钮「{resources.DEFAULT_VIDEO_BUTTON_PATH.name}」成功")
 
     @override
     async def render_image(self, result: ParseResult) -> bytes:

--- a/src/nonebot_plugin_parser/renders/common.py
+++ b/src/nonebot_plugin_parser/renders/common.py
@@ -21,7 +21,7 @@ PILImageDraw = ImageDraw.ImageDraw
 
 try:
     import emosvg
-except ImportError:
+except (ImportError, OSError):
     emosvg = None
 
 

--- a/src/nonebot_plugin_parser/renders/htmlrender.py
+++ b/src/nonebot_plugin_parser/renders/htmlrender.py
@@ -1,5 +1,7 @@
-from typing import Any
+from __future__ import annotations
+
 from pathlib import Path
+from dataclasses import field, dataclass
 from typing_extensions import override
 
 from nonebot import require
@@ -7,7 +9,121 @@ from nonebot import require
 require("nonebot_plugin_htmlrender")
 from nonebot_plugin_htmlrender import template_to_pic
 
-from .base import ParseResult, ImageRenderer
+from .base import ImageRenderer, ParseResult
+from .common import CommonRenderer
+
+
+# region 模板数据类
+
+
+@dataclass(slots=True)
+class CardPlatform:
+    """卡片模板中的平台信息。
+
+    Attributes:
+        name: 平台标识名，如 ``bilibili``、``weibo``
+        display_name: 用于展示的平台中文名
+        logo_path: 平台 logo 的 file URI，不存在时为 ``None``
+    """
+
+    name: str
+    display_name: str
+    logo_path: str | None = None
+
+
+@dataclass(slots=True)
+class CardAuthor:
+    """卡片模板中的作者信息。
+
+    Attributes:
+        name: 作者名称
+        avatar_path: 头像的 file URI，无头像时为 ``None``
+    """
+
+    name: str
+    avatar_path: str | None = None
+
+
+@dataclass(slots=True)
+class CardVideoContent:
+    """卡片模板中的单个视频内容。
+
+    Attributes:
+        cover_path: 视频封面的 file URI
+        duration: 格式化后的时长字符串，如 ``"时长: 3:42"``
+    """
+
+    cover_path: str | None = None
+    duration: str | None = None
+
+
+@dataclass(slots=True)
+class CardImageContent:
+    """卡片模板中的单张图片。
+
+    Attributes:
+        path: 图片的 file URI
+    """
+
+    path: str
+
+
+@dataclass(slots=True)
+class CardGraphicsContent:
+    """卡片模板中的图文混排内容。
+
+    Attributes:
+        path: 图片的 file URI
+        text: 图片上方的文本
+        alt: 图片描述（居中显示）
+    """
+
+    path: str
+    text: str | None = None
+    alt: str | None = None
+
+
+@dataclass(slots=True)
+class CardData:
+    """HTML 卡片渲染的完整模板数据。
+
+    Jinja2 模板通过属性访问（如 ``result.title``）读取数据，
+    与 ``dict`` 的中括号访问行为一致，无需修改模板。
+
+    Attributes:
+        title: 标题
+        text: 正文内容
+        formartted_datetime: 格式化后的发布时间
+        extra_info: 额外信息文本
+        platform: 平台信息
+        author: 作者信息
+        video_contents: 视频内容列表（封面 + 时长）
+        cover_path: 首个视频封面的 file URI（兼容字段）
+        img_contents: 图片内容列表
+        graphics_contents: 图文内容列表
+        content_type: 推断的内容类型标签（"视频" / "图文" / "动态"）
+        play_icon_uri: 播放按钮图标的 file URI
+        font_uri: 中文字体的 file URI
+        repost: 转发内容（递归结构）
+    """
+
+    title: str | None = None
+    text: str | None = None
+    formartted_datetime: str | None = None
+    extra_info: str | None = None
+    platform: CardPlatform | None = None
+    author: CardAuthor | None = None
+    video_contents: list[CardVideoContent] = field(default_factory=list)
+    cover_path: str | None = None
+    img_contents: list[CardImageContent] = field(default_factory=list)
+    graphics_contents: list[CardGraphicsContent] = field(default_factory=list)
+    content_type: str | None = None
+    play_icon_uri: str | None = None
+    font_uri: str | None = None
+    repost: CardData | None = None
+
+
+# endregion
 
 
 class HtmlRenderer(ImageRenderer):
@@ -15,74 +131,101 @@ class HtmlRenderer(ImageRenderer):
 
     @override
     async def render_image(self, result: ParseResult) -> bytes:
-        # 准备模板数据
         template_data = await self._resolve_parse_result(result)
 
-        # 渲染图片
         return await template_to_pic(
             template_path=str(self.templates_dir),
             template_name="card.html.jinja",
             templates={"result": template_data},
             pages={
-                "viewport": {"width": 800, "height": 100},  # 高度会自动调整
+                "viewport": {"width": 800, "height": 100},
                 "base_url": f"file://{self.templates_dir}",
             },
         )
 
-    async def _resolve_parse_result(self, result: ParseResult) -> dict[str, Any]:
-        """解析 ParseResult 为模板可用的字典数据，并处理异步资源路径"""
-        data: dict[str, Any] = {
-            "title": result.title,
-            "text": result.text,
-            "formartted_datetime": result.formartted_datetime,
-            "extra_info": result.extra_info,
-        }
-
+    async def _resolve_parse_result(self, result: ParseResult) -> CardData:
+        """将 ``ParseResult`` 解析为模板可用的 ``CardData``，并等待异步资源路径。"""
+        # 平台
+        platform: CardPlatform | None = None
         if result.platform:
-            data["platform"] = {
-                "display_name": result.platform.display_name,
-                "name": result.platform.name,
-            }
-            # 尝试获取平台 logo
-            logo_path = Path(__file__).parent / "resources" / f"{result.platform.name}.png"
-            if logo_path.exists():
-                data["platform"]["logo_path"] = logo_path.as_uri()
+            logo_path = CommonRenderer.RESOURCES_DIR / f"{result.platform.name}.png"
+            platform = CardPlatform(
+                name=result.platform.name,
+                display_name=result.platform.display_name,
+                logo_path=logo_path.as_uri() if logo_path.exists() else None,
+            )
 
-        # 处理作者信息
+        # 作者
+        author: CardAuthor | None = None
         if result.author:
             avatar_path = await result.author.get_avatar_path()
-            data["author"] = {
-                "name": result.author.name,
-                "avatar_path": avatar_path.as_uri() if avatar_path else None,
-            }
+            # 无头像时 fallback 到默认头像（与 CommonRenderer 保持一致）
+            if not avatar_path:
+                avatar_path = CommonRenderer.DEFAULT_AVATAR_PATH if CommonRenderer.DEFAULT_AVATAR_PATH.exists() else None
+            author = CardAuthor(
+                name=result.author.name,
+                avatar_path=avatar_path.as_uri() if avatar_path else None,
+            )
 
-        # 处理封面
-        cover_path = await result.cover_path
-        if cover_path:
-            data["cover_path"] = cover_path.as_uri()
+        # 视频内容
+        video_contents: list[CardVideoContent] = []
+        for vc in result.video_contents:
+            cover = await vc.get_cover_path()
+            video_contents.append(CardVideoContent(
+                cover_path=cover.as_uri() if cover else None,
+                duration=vc.display_duration if vc.duration else None,
+            ))
 
-        # 处理图片内容
-        img_contents = []
+        cover_path = video_contents[0].cover_path if video_contents else None
+
+        # 图片内容
+        img_contents: list[CardImageContent] = []
         for img in result.img_contents:
             path = await img.get_path()
-            img_contents.append({"path": path.as_uri()})
-        data["img_contents"] = img_contents
+            img_contents.append(CardImageContent(path=path.as_uri()))
 
-        # 处理图文内容
-        graphics_contents = []
+        # 图文内容
+        graphics_contents: list[CardGraphicsContent] = []
         for graphics in result.graphics_contents:
             path = await graphics.get_path()
-            graphics_contents.append(
-                {
-                    "path": path.as_uri(),
-                    "text": graphics.text,
-                    "alt": graphics.alt,
-                }
-            )
-        data["graphics_contents"] = graphics_contents
+            graphics_contents.append(CardGraphicsContent(
+                path=path.as_uri(),
+                text=graphics.text,
+                alt=graphics.alt,
+            ))
 
-        # 处理转发内容
-        if result.repost:
-            data["repost"] = await self._resolve_parse_result(result.repost)
+        # 内容类型推断
+        if video_contents:
+            content_type = "视频"
+        elif graphics_contents:
+            content_type = "图文"
+        elif img_contents:
+            content_type = "动态"
+        elif result.repost:
+            content_type = "动态"
+        else:
+            content_type = None
 
-        return data
+        # 转发
+        repost = await self._resolve_parse_result(result.repost) if result.repost else None
+
+        # 播放按钮 & 字体（使用 CommonRenderer 定义的常量，保持一致）
+        play_icon_uri = CommonRenderer.DEFAULT_VIDEO_BUTTON_PATH.as_uri() if CommonRenderer.DEFAULT_VIDEO_BUTTON_PATH.exists() else None
+        font_uri = CommonRenderer.DEFAULT_FONT_PATH.as_uri() if CommonRenderer.DEFAULT_FONT_PATH.exists() else None
+
+        return CardData(
+            title=result.title,
+            text=result.text,
+            formartted_datetime=result.formartted_datetime,
+            extra_info=result.extra_info,
+            platform=platform,
+            author=author,
+            video_contents=video_contents,
+            cover_path=cover_path,
+            img_contents=img_contents,
+            graphics_contents=graphics_contents,
+            content_type=content_type,
+            play_icon_uri=play_icon_uri,
+            font_uri=font_uri,
+            repost=repost,
+        )

--- a/src/nonebot_plugin_parser/renders/htmlrender.py
+++ b/src/nonebot_plugin_parser/renders/htmlrender.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from pathlib import Path
 from dataclasses import field, dataclass
 from typing_extensions import override
 
@@ -9,13 +8,10 @@ from nonebot import require
 require("nonebot_plugin_htmlrender")
 from nonebot_plugin_htmlrender import template_to_pic
 
-from .base import ImageRenderer, ParseResult
+from .base import ParseResult, ImageRenderer
+from ..utils import fmt_duration
 from .common import CommonRenderer
 from ..config import pconfig
-from ..utils import fmt_duration
-
-
-# region 模板数据类
 
 
 @dataclass(slots=True)
@@ -25,7 +21,7 @@ class CardPlatform:
     Attributes:
         name: 平台标识名，如 ``bilibili``、``weibo``
         display_name: 用于展示的平台中文名
-        logo_path: 平台 logo 的 file URI，不存在时为 ``None``
+        logo_path: 平台 logo 的 file URI, 不存在时为 ``None``
     """
 
     name: str
@@ -100,10 +96,10 @@ class CardData:
         platform: 平台信息
         author: 作者信息
         video_contents: 视频内容列表（封面 + 时长）
-        cover_path: 首个视频封面的 file URI（兼容字段）
+        cover_path: 首个视频封面的 file URI (兼容字段)
         img_contents: 图片内容列表
         graphics_contents: 图文内容列表
-        content_type: 推断的内容类型标签（"视频" / "图文" / "动态"）
+        content_type: 推断的内容类型标签 ("视频" / "图文" / "动态")
         play_icon_uri: 播放按钮图标的 file URI
         font_uri: 中文字体的 file URI
         repost: 转发内容（递归结构）
@@ -123,9 +119,6 @@ class CardData:
     play_icon_uri: str | None = None
     font_uri: str | None = None
     repost: CardData | None = None
-
-
-# endregion
 
 
 class HtmlRenderer(ImageRenderer):

--- a/src/nonebot_plugin_parser/renders/htmlrender.py
+++ b/src/nonebot_plugin_parser/renders/htmlrender.py
@@ -12,6 +12,7 @@ from nonebot_plugin_htmlrender import template_to_pic
 from .base import ImageRenderer, ParseResult
 from .common import CommonRenderer
 from ..config import pconfig
+from ..utils import fmt_duration
 
 
 # region 模板数据类
@@ -196,9 +197,7 @@ class HtmlRenderer(ImageRenderer):
             duration_secs = result.extra.get("duration", 0)
             duration_str = None
             if duration_secs:
-                minutes = int(duration_secs) // 60
-                seconds = int(duration_secs) % 60
-                duration_str = f"时长: {minutes}:{seconds:02d}"
+                duration_str = f"时长: {fmt_duration(duration_secs)}"
             video_contents.append(
                 CardVideoContent(
                     cover_path=promoted.path,

--- a/src/nonebot_plugin_parser/renders/htmlrender.py
+++ b/src/nonebot_plugin_parser/renders/htmlrender.py
@@ -14,7 +14,7 @@ class HtmlRenderer(ImageRenderer):
 
     @override
     async def render_image(self, result: ParseResult) -> bytes:
-        await result.ensure_img_ready()
+        await result.ensure_imgs_ready()
 
         logo = resources.RESOURCES_DIR / f"{result.platform.name}.png"
         logo = logo.as_uri() if logo.exists() else None
@@ -31,8 +31,5 @@ class HtmlRenderer(ImageRenderer):
                 "font": font,
                 "play_button": play_button,
             },
-            pages={
-                "viewport": {"width": 800, "height": 100},
-                "base_url": f"file://{self.templates_dir}",
-            },
+            pages={"viewport": {"width": 800, "height": 100}},
         )

--- a/src/nonebot_plugin_parser/renders/htmlrender.py
+++ b/src/nonebot_plugin_parser/renders/htmlrender.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from dataclasses import field, dataclass
 from typing_extensions import override
 
 from nonebot import require
@@ -8,118 +7,8 @@ from nonebot import require
 require("nonebot_plugin_htmlrender")
 from nonebot_plugin_htmlrender import template_to_pic
 
-from .base import ParseResult, ImageRenderer
-from ..utils import fmt_duration
-from .common import CommonRenderer
-from ..config import pconfig
-
-
-@dataclass(slots=True)
-class CardPlatform:
-    """卡片模板中的平台信息。
-
-    Attributes:
-        name: 平台标识名，如 ``bilibili``、``weibo``
-        display_name: 用于展示的平台中文名
-        logo_path: 平台 logo 的 file URI, 不存在时为 ``None``
-    """
-
-    name: str
-    display_name: str
-    logo_path: str | None = None
-
-
-@dataclass(slots=True)
-class CardAuthor:
-    """卡片模板中的作者信息。
-
-    Attributes:
-        name: 作者名称
-        avatar_path: 头像的 file URI，无头像时为 ``None``
-    """
-
-    name: str
-    avatar_path: str | None = None
-
-
-@dataclass(slots=True)
-class CardVideoContent:
-    """卡片模板中的单个视频内容。
-
-    Attributes:
-        cover_path: 视频封面的 file URI
-        duration: 格式化后的时长字符串，如 ``"时长: 3:42"``
-    """
-
-    cover_path: str | None = None
-    duration: str | None = None
-
-
-@dataclass(slots=True)
-class CardImageContent:
-    """卡片模板中的单张图片。
-
-    Attributes:
-        path: 图片的 file URI
-    """
-
-    path: str
-
-
-@dataclass(slots=True)
-class CardGraphicsContent:
-    """卡片模板中的图文混排内容。
-
-    Attributes:
-        path: 图片的 file URI
-        text: 图片上方的文本
-        alt: 图片描述（居中显示）
-    """
-
-    path: str
-    text_before: str | None = None
-    text_after: str | None = None
-    alt: str | None = None
-
-
-@dataclass(slots=True)
-class CardData:
-    """HTML 卡片渲染的完整模板数据。
-
-    Jinja2 模板通过属性访问（如 ``result.title``）读取数据，
-    与 ``dict`` 的中括号访问行为一致，无需修改模板。
-
-    Attributes:
-        title: 标题
-        text: 正文内容
-        formartted_datetime: 格式化后的发布时间
-        extra_info: 额外信息文本
-        platform: 平台信息
-        author: 作者信息
-        video_contents: 视频内容列表（封面 + 时长）
-        cover_path: 首个视频封面的 file URI (兼容字段)
-        img_contents: 图片内容列表
-        graphics_contents: 图文内容列表
-        content_type: 推断的内容类型标签 ("视频" / "图文" / "动态")
-        play_icon_uri: 播放按钮图标的 file URI
-        font_uri: 中文字体的 file URI
-        repost: 转发内容（递归结构）
-    """
-
-    title: str | None = None
-    text: str | None = None
-    formartted_datetime: str | None = None
-    extra_info: str | None = None
-    platform: CardPlatform | None = None
-    author: CardAuthor | None = None
-    video_contents: list[CardVideoContent] = field(default_factory=list)
-    cover_path: str | None = None
-    img_contents: list[CardImageContent] = field(default_factory=list)
-    graphics_contents: list[CardGraphicsContent] = field(default_factory=list)
-    content_type: str | None = None
-    play_icon_uri: str | None = None
-    font_uri: str | None = None
-    repost: CardData | None = None
+from . import resources
+from .base import ParseResult, ImageRenderer, pconfig
 
 
 class HtmlRenderer(ImageRenderer):
@@ -127,129 +16,42 @@ class HtmlRenderer(ImageRenderer):
 
     @override
     async def render_image(self, result: ParseResult) -> bytes:
-        template_data = await self._resolve_parse_result(result)
+        # await self._resolve_parse_result(result)
+        await result.ensure_img_ready()
+
+        logo = resources.RESOURCES_DIR / f"{result.platform.name}.png"
+        logo = logo.as_uri() if logo.exists() else None
+        font = pconfig.custom_font or resources.DEFAULT_FONT_PATH
+        font = font.as_uri() if font.exists() else None
+        play_button = resources.DEFAULT_VIDEO_BUTTON_PATH.as_uri()
+
+        # 动态视频标记：将首张图片提升为视频封面（播放按钮 + 时长）
+        # is_video = result.extra.get("is_video", False)
+        # if is_video and img_contents and not video_contents:
+        #     promoted = img_contents.pop(0)
+        #     duration_secs = result.extra.get("duration", 0)
+        #     duration_str = None
+        #     if duration_secs:
+        #         duration_str = f"时长: {fmt_duration(duration_secs)}"
+        #     video_contents.append(
+        #         CardVideoContent(
+        #             cover_path=promoted.path,
+        #             duration=duration_str,
+        #         )
+        #     )
+        #     cover_path = promoted.path
 
         return await template_to_pic(
             template_path=str(self.templates_dir),
             template_name="card.html.jinja",
-            templates={"result": template_data},
+            templates={
+                "result": result,
+                "logo": logo,
+                "font": font,
+                "play_button": play_button,
+            },
             pages={
                 "viewport": {"width": 800, "height": 100},
                 "base_url": f"file://{self.templates_dir}",
             },
-        )
-
-    async def _resolve_parse_result(self, result: ParseResult) -> CardData:
-        """将 ``ParseResult`` 解析为模板可用的 ``CardData``，并等待异步资源路径。"""
-        # 平台
-        platform: CardPlatform | None = None
-        if result.platform:
-            logo_path = CommonRenderer.RESOURCES_DIR / f"{result.platform.name}.png"
-            platform = CardPlatform(
-                name=result.platform.name,
-                display_name=result.platform.display_name,
-                logo_path=logo_path.as_uri() if logo_path.exists() else None,
-            )
-
-        # 作者
-        author: CardAuthor | None = None
-        if result.author:
-            avatar_path = await result.author.get_avatar_path()
-            # 无头像时 fallback 到默认头像（与 CommonRenderer 保持一致）
-            if not avatar_path:
-                avatar_path = (
-                    CommonRenderer.DEFAULT_AVATAR_PATH if CommonRenderer.DEFAULT_AVATAR_PATH.exists() else None
-                )
-            author = CardAuthor(
-                name=result.author.name,
-                avatar_path=avatar_path.as_uri() if avatar_path else None,
-            )
-
-        # 视频内容
-        video_contents: list[CardVideoContent] = []
-        for vc in result.video_contents:
-            cover = await vc.get_cover_path()
-            video_contents.append(
-                CardVideoContent(
-                    cover_path=cover.as_uri() if cover else None,
-                    duration=vc.display_duration if vc.duration else None,
-                )
-            )
-
-        cover_path = video_contents[0].cover_path if video_contents else None
-
-        # 图片内容
-        img_contents: list[CardImageContent] = []
-        for img in result.img_contents:
-            path = await img.get_path()
-            img_contents.append(CardImageContent(path=path.as_uri()))
-
-        # 动态视频标记：将首张图片提升为视频封面（播放按钮 + 时长）
-        is_video = result.extra.get("is_video", False)
-        if is_video and img_contents and not video_contents:
-            promoted = img_contents.pop(0)
-            duration_secs = result.extra.get("duration", 0)
-            duration_str = None
-            if duration_secs:
-                duration_str = f"时长: {fmt_duration(duration_secs)}"
-            video_contents.append(
-                CardVideoContent(
-                    cover_path=promoted.path,
-                    duration=duration_str,
-                )
-            )
-            cover_path = promoted.path
-
-        # 图文内容
-        graphics_contents: list[CardGraphicsContent] = []
-        for graphics in result.graphics_contents:
-            path = await graphics.get_path()
-            graphics_contents.append(
-                CardGraphicsContent(
-                    path=path.as_uri(),
-                    text_before=graphics.text_before,
-                    text_after=graphics.text_after,
-                    alt=graphics.alt,
-                )
-            )
-
-        # 内容类型推断（允许解析器通过 extra 显式指定）
-        content_type = result.extra.get("content_type")
-        if content_type is None:
-            if video_contents:
-                content_type = "视频"
-            elif graphics_contents:
-                content_type = "图文"
-            elif img_contents:
-                content_type = "动态"
-            elif result.repost:
-                content_type = "动态"
-
-        # 转发
-        repost = await self._resolve_parse_result(result.repost) if result.repost else None
-
-        # 播放按钮 & 字体（使用 CommonRenderer 定义的常量，保持一致）
-        play_icon_uri = (
-            CommonRenderer.DEFAULT_VIDEO_BUTTON_PATH.as_uri()
-            if CommonRenderer.DEFAULT_VIDEO_BUTTON_PATH.exists()
-            else None
-        )
-        font_path = pconfig.custom_font or CommonRenderer.DEFAULT_FONT_PATH
-        font_uri = font_path.as_uri() if font_path.exists() else None
-
-        return CardData(
-            title=result.title,
-            text=result.text,
-            formartted_datetime=result.formartted_datetime,
-            extra_info=result.extra_info,
-            platform=platform,
-            author=author,
-            video_contents=video_contents,
-            cover_path=cover_path,
-            img_contents=img_contents,
-            graphics_contents=graphics_contents,
-            content_type=content_type,
-            play_icon_uri=play_icon_uri,
-            font_uri=font_uri,
-            repost=repost,
         )

--- a/src/nonebot_plugin_parser/renders/htmlrender.py
+++ b/src/nonebot_plugin_parser/renders/htmlrender.py
@@ -161,7 +161,9 @@ class HtmlRenderer(ImageRenderer):
             avatar_path = await result.author.get_avatar_path()
             # 无头像时 fallback 到默认头像（与 CommonRenderer 保持一致）
             if not avatar_path:
-                avatar_path = CommonRenderer.DEFAULT_AVATAR_PATH if CommonRenderer.DEFAULT_AVATAR_PATH.exists() else None
+                avatar_path = (
+                    CommonRenderer.DEFAULT_AVATAR_PATH if CommonRenderer.DEFAULT_AVATAR_PATH.exists() else None
+                )
             author = CardAuthor(
                 name=result.author.name,
                 avatar_path=avatar_path.as_uri() if avatar_path else None,
@@ -171,10 +173,12 @@ class HtmlRenderer(ImageRenderer):
         video_contents: list[CardVideoContent] = []
         for vc in result.video_contents:
             cover = await vc.get_cover_path()
-            video_contents.append(CardVideoContent(
-                cover_path=cover.as_uri() if cover else None,
-                duration=vc.display_duration if vc.duration else None,
-            ))
+            video_contents.append(
+                CardVideoContent(
+                    cover_path=cover.as_uri() if cover else None,
+                    duration=vc.display_duration if vc.duration else None,
+                )
+            )
 
         cover_path = video_contents[0].cover_path if video_contents else None
 
@@ -184,33 +188,57 @@ class HtmlRenderer(ImageRenderer):
             path = await img.get_path()
             img_contents.append(CardImageContent(path=path.as_uri()))
 
+        # 动态视频标记：将首张图片提升为视频封面（播放按钮 + 时长）
+        is_video = result.extra.get("is_video", False)
+        if is_video and img_contents and not video_contents:
+            promoted = img_contents.pop(0)
+            duration_secs = result.extra.get("duration", 0)
+            duration_str = None
+            if duration_secs:
+                minutes = int(duration_secs) // 60
+                seconds = int(duration_secs) % 60
+                duration_str = f"时长: {minutes}:{seconds:02d}"
+            video_contents.append(
+                CardVideoContent(
+                    cover_path=promoted.path,
+                    duration=duration_str,
+                )
+            )
+            cover_path = promoted.path
+
         # 图文内容
         graphics_contents: list[CardGraphicsContent] = []
         for graphics in result.graphics_contents:
             path = await graphics.get_path()
-            graphics_contents.append(CardGraphicsContent(
-                path=path.as_uri(),
-                text=graphics.text,
-                alt=graphics.alt,
-            ))
+            graphics_contents.append(
+                CardGraphicsContent(
+                    path=path.as_uri(),
+                    text=graphics.text,
+                    alt=graphics.alt,
+                )
+            )
 
-        # 内容类型推断
-        if video_contents:
-            content_type = "视频"
-        elif graphics_contents:
-            content_type = "图文"
-        elif img_contents:
-            content_type = "动态"
-        elif result.repost:
-            content_type = "动态"
-        else:
-            content_type = None
+        # 内容类型推断（允许解析器通过 extra 显式指定）
+        content_type = result.extra.get("content_type")
+        if content_type is None:
+            if video_contents:
+                content_type = "视频"
+            elif graphics_contents:
+                content_type = "图文"
+            elif img_contents:
+                content_type = "动态"
+            elif result.repost:
+                content_type = "动态"
 
         # 转发
         repost = await self._resolve_parse_result(result.repost) if result.repost else None
 
         # 播放按钮 & 字体（使用 CommonRenderer 定义的常量，保持一致）
-        play_icon_uri = CommonRenderer.DEFAULT_VIDEO_BUTTON_PATH.as_uri() if CommonRenderer.DEFAULT_VIDEO_BUTTON_PATH.exists() else None
+        play_icon_uri = (
+            CommonRenderer.DEFAULT_VIDEO_BUTTON_PATH.as_uri()
+            if CommonRenderer.DEFAULT_VIDEO_BUTTON_PATH.exists()
+            else None
+        )
         font_uri = CommonRenderer.DEFAULT_FONT_PATH.as_uri() if CommonRenderer.DEFAULT_FONT_PATH.exists() else None
 
         return CardData(

--- a/src/nonebot_plugin_parser/renders/htmlrender.py
+++ b/src/nonebot_plugin_parser/renders/htmlrender.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from typing_extensions import override
 
 from nonebot import require
@@ -16,7 +14,6 @@ class HtmlRenderer(ImageRenderer):
 
     @override
     async def render_image(self, result: ParseResult) -> bytes:
-        # await self._resolve_parse_result(result)
         await result.ensure_img_ready()
 
         logo = resources.RESOURCES_DIR / f"{result.platform.name}.png"
@@ -24,22 +21,6 @@ class HtmlRenderer(ImageRenderer):
         font = pconfig.custom_font or resources.DEFAULT_FONT_PATH
         font = font.as_uri() if font.exists() else None
         play_button = resources.DEFAULT_VIDEO_BUTTON_PATH.as_uri()
-
-        # 动态视频标记：将首张图片提升为视频封面（播放按钮 + 时长）
-        # is_video = result.extra.get("is_video", False)
-        # if is_video and img_contents and not video_contents:
-        #     promoted = img_contents.pop(0)
-        #     duration_secs = result.extra.get("duration", 0)
-        #     duration_str = None
-        #     if duration_secs:
-        #         duration_str = f"时长: {fmt_duration(duration_secs)}"
-        #     video_contents.append(
-        #         CardVideoContent(
-        #             cover_path=promoted.path,
-        #             duration=duration_str,
-        #         )
-        #     )
-        #     cover_path = promoted.path
 
         return await template_to_pic(
             template_path=str(self.templates_dir),

--- a/src/nonebot_plugin_parser/renders/htmlrender.py
+++ b/src/nonebot_plugin_parser/renders/htmlrender.py
@@ -11,6 +11,7 @@ from nonebot_plugin_htmlrender import template_to_pic
 
 from .base import ImageRenderer, ParseResult
 from .common import CommonRenderer
+from ..config import pconfig
 
 
 # region 模板数据类
@@ -239,7 +240,8 @@ class HtmlRenderer(ImageRenderer):
             if CommonRenderer.DEFAULT_VIDEO_BUTTON_PATH.exists()
             else None
         )
-        font_uri = CommonRenderer.DEFAULT_FONT_PATH.as_uri() if CommonRenderer.DEFAULT_FONT_PATH.exists() else None
+        font_path = pconfig.custom_font or CommonRenderer.DEFAULT_FONT_PATH
+        font_uri = font_path.as_uri() if font_path.exists() else None
 
         return CardData(
             title=result.title,

--- a/src/nonebot_plugin_parser/renders/resources/__init__.py
+++ b/src/nonebot_plugin_parser/renders/resources/__init__.py
@@ -1,0 +1,10 @@
+from pathlib import Path
+
+RESOURCES_DIR = Path(__file__).parent
+"""默认资源目录"""
+DEFAULT_FONT_PATH = RESOURCES_DIR / "HYSongYunLangHeiW.ttf"
+"""默认字体文件路径"""
+DEFAULT_AVATAR_PATH = RESOURCES_DIR / "avatar.png"
+"""默认头像文件路径"""
+DEFAULT_VIDEO_BUTTON_PATH = RESOURCES_DIR / "play.png"
+"""默认视频播放按钮文件路径"""

--- a/src/nonebot_plugin_parser/renders/templates/card.html.jinja
+++ b/src/nonebot_plugin_parser/renders/templates/card.html.jinja
@@ -496,6 +496,11 @@
       {% endif %}
 
       <div class="content-body">
+        {# ── Title（非视频：标题属于动态本身，放在封面上方） ── #}
+        {% if result.title and not result.video_contents %}
+        <div class="title">{{ result.title }}</div>
+        {% endif %}
+
         {# ── 动态类型：文字显示在封面上方 ── #}
         {% if result.content_type == '动态' and result.text %}
         <div class="text">{{ result.text }}</div>
@@ -521,8 +526,8 @@
         {% endif %}
         {% endif %}
 
-        {# ── Title ── #}
-        {% if result.title %}
+        {# ── Title（有视频：标题属于视频，放在封面下方） ── #}
+        {% if result.title and result.video_contents %}
         <div class="title">{{ result.title }}</div>
         {% endif %}
 

--- a/src/nonebot_plugin_parser/renders/templates/card.html.jinja
+++ b/src/nonebot_plugin_parser/renders/templates/card.html.jinja
@@ -5,10 +5,10 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Media Card</title>
     <style>
-      {% if result.font_uri %}
+      {% if font %}
       @font-face {
         font-family: 'CustomFont';
-        src: url('{{ result.font_uri | safe }}');
+        src: url('{{ font | safe }}');
       }
       {% endif %}
 
@@ -108,7 +108,7 @@
       * { box-sizing: border-box; margin: 0; padding: 0; }
 
       body {
-        font-family: {% if result.font_uri %}'CustomFont', {% endif %}"Noto Sans SC", "PingFang SC", "Microsoft YaHei", system-ui, sans-serif;
+        font-family: {% if font %}'CustomFont', {% endif %}"Noto Sans SC", "PingFang SC", "Microsoft YaHei", system-ui, sans-serif;
         width: 800px;
         padding: 24px;
         background: linear-gradient(160deg, var(--grad-from) 0%, var(--grad-via) 50%, var(--grad-to) 100%);
@@ -480,8 +480,8 @@
       {# ── Header ── #}
       {% if result.author %}
       <div class="header">
-        {% if result.author.avatar_path %}
-        <img src="{{ result.author.avatar_path | safe }}" class="avatar" alt="avatar" />
+        {% if result.author.avatar_path_uri %}
+        <img src="{{ result.author.avatar_path_uri | safe }}" class="avatar" alt="avatar" />
         {% endif %}
         <div class="user-info">
           <div class="username">{{ result.author.name }}</div>
@@ -489,8 +489,8 @@
           <div class="time">{{ result.formartted_datetime }}</div>
           {% endif %}
         </div>
-        {% if not is_repost and result.platform and result.platform.logo_path %}
-        <img src="{{ result.platform.logo_path | safe }}" class="platform-logo" alt="{{ result.platform.display_name }}" />
+        {% if not is_repost and result.platform and logo %}
+        <img src="{{ logo | safe }}" class="platform-logo" alt="{{ result.platform.display_name }}" />
         {% endif %}
       </div>
       {% endif %}
@@ -509,12 +509,12 @@
         {# ── 视频封面 ── #}
         {% if result.video_contents %}
         {% set vc = result.video_contents[0] %}
-        {% if vc.cover_path %}
+        {% if vc.cover_path_uri %}
         <div class="cover-wrapper">
-          <img src="{{ vc.cover_path | safe }}" class="cover-img" alt="cover" />
-          {% if result.play_icon_uri %}
+          <img src="{{ vc.cover_path_uri | safe }}" class="cover-img" alt="cover" />
+          {% if play_button %}
           <div class="play-button">
-            <img src="{{ result.play_icon_uri | safe }}" alt="play" />
+            <img src="{{ play_button | safe }}" alt="play" />
           </div>
           {% endif %}
           {% if vc.duration %}
@@ -545,7 +545,7 @@
         {% set count = imgs|length %}
         {% if count == 1 %}
         <div class="image-container">
-          <img src="{{ imgs[0].path | safe }}" class="single-image" alt="image" />
+          <img src="{{ imgs[0].path_uri | safe }}" class="single-image" alt="image" />
         </div>
         {% else %}
         {% set cols = 3 %}
@@ -553,7 +553,7 @@
         <div class="image-grid cols-{{ cols }}">
           {% for img in imgs[:9] %}
           <div class="grid-item">
-            <img src="{{ img.path | safe }}" alt="image" />
+            <img src="{{ img.path_uri | safe }}" alt="image" />
             {% if loop.last and count > 9 %}
             <div class="more-count">+{{ count - 9 }}</div>
             {% endif %}
@@ -570,7 +570,7 @@
           <div class="text">{{ graphics.text_before }}</div>
           {% endif %}
           <div class="image-container">
-            <img src="{{ graphics.path | safe }}" class="single-image" alt="graphics" />
+            <img src="{{ graphics.path_uri | safe }}" class="single-image" alt="graphics" />
           </div>
           {% if graphics.alt %}
           <div class="graphics-alt">{{ graphics.alt }}</div>

--- a/src/nonebot_plugin_parser/renders/templates/card.html.jinja
+++ b/src/nonebot_plugin_parser/renders/templates/card.html.jinja
@@ -239,7 +239,7 @@
       }
 
       .title {
-        font-size: 26px;
+        font-size: 24px;
         font-weight: 800;
         color: var(--text-primary);
         line-height: 1.4;

--- a/src/nonebot_plugin_parser/renders/templates/card.html.jinja
+++ b/src/nonebot_plugin_parser/renders/templates/card.html.jinja
@@ -314,9 +314,10 @@
       }
 
       .play-button img {
-        width: 50%;
-        height: 50%;
+        width: 100%;
+        height: 100%;
         object-fit: contain;
+        opacity: 0.5;
       }
 
       /* ──────── 图片网格 ──────── */

--- a/src/nonebot_plugin_parser/renders/templates/card.html.jinja
+++ b/src/nonebot_plugin_parser/renders/templates/card.html.jinja
@@ -566,14 +566,17 @@
         {% elif result.graphics_contents %}
         {% for graphics in result.graphics_contents %}
         <div class="graphics-item">
-          {% if graphics.text %}
-          <div class="text">{{ graphics.text }}</div>
+          {% if graphics.text_before %}
+          <div class="text">{{ graphics.text_before }}</div>
           {% endif %}
           <div class="image-container">
             <img src="{{ graphics.path | safe }}" class="single-image" alt="graphics" />
           </div>
           {% if graphics.alt %}
           <div class="graphics-alt">{{ graphics.alt }}</div>
+          {% endif %}
+          {% if graphics.text_after %}
+          <div class="text">{{ graphics.text_after }}</div>
           {% endif %}
         </div>
         {% endfor %}

--- a/src/nonebot_plugin_parser/renders/templates/card.html.jinja
+++ b/src/nonebot_plugin_parser/renders/templates/card.html.jinja
@@ -5,79 +5,141 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Media Card</title>
     <style>
-      @import url("https://fonts.googleapis.com/css2?family=Noto+Sans+SC:wght@400;500;700&family=Inter:wght@400;500;600;700&display=swap");
+      {% if result.font_uri %}
+      @font-face {
+        font-family: 'HYSongYunLangHei';
+        src: url('{{ result.font_uri | safe }}');
+      }
+      {% endif %}
 
       :root {
-        /* Color Palette - Slate & Indigo */
-        --bg-color: #f1f5f9;
-        --card-bg: #ffffff;
-        --text-primary: #1e293b; /* Slate 800 */
-        --text-secondary: #64748b; /* Slate 500 */
-        --accent-color: #6366f1; /* Indigo 500 */
-        --border-color: #e2e8f0; /* Slate 200 */
-        --repost-bg: #f8fafc; /* Slate 50 */
-        
-        /* Shadows */
-        --shadow-sm: 0 1px 2px 0 rgb(0 0 0 / 0.05);
-        --shadow-md: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1);
-        --shadow-xl: 0 20px 25px -5px rgb(0 0 0 / 0.1), 0 8px 10px -6px rgb(0 0 0 / 0.1);
-        
-        /* Radius */
-        --radius-2xl: 24px;
-        --radius-xl: 16px;
-        --radius-lg: 12px;
-        --radius-md: 8px;
+        /* ── 默认配色 (fallback) ── */
+        --primary: #6366f1;
+        --grad-from: #eeeefd;
+        --grad-via: #dddefa;
+        --grad-to: #c7c8fa;
+        --accent-bg: rgba(99,102,241,0.08);
+
+        /* ── 通用 token ── */
+        --card-bg: rgba(255,255,255,0.60);
+        --text-primary: #1e293b;
+        --text-secondary: #64748b;
+        --repost-bg: rgba(255,255,255,0.30);
+        --repost-border: rgba(255,255,255,0.50);
+        --radius-card: 18px;
+        --radius-img: 12px;
+        --radius-sm: 6px;
+        --shadow-card: -2px -2px 8px rgba(0,0,0,0.03), 6px 8px 24px rgba(0,0,0,0.10), 12px 16px 48px rgba(0,0,0,0.08);
       }
 
-      * {
-        box-sizing: border-box;
-        margin: 0;
-        padding: 0;
+      /* ──────── 平台主题 ──────── */
+      [data-platform="bilibili"] {
+        --primary: #00a1d6;
+        --grad-from: #c8e4f2;
+        --grad-via: #c8ebf5;
+        --grad-to: #a8ddf0;
+        --accent-bg: rgba(0,161,214,0.10);
       }
+      [data-platform="weibo"] {
+        --primary: #e6162d;
+        --grad-from: #f6d4d4;
+        --grad-via: #f0b0b0;
+        --grad-to: #e88a8a;
+        --accent-bg: rgba(230,22,45,0.10);
+      }
+      [data-platform="xiaohongshu"] {
+        --primary: #ff2442;
+        --grad-from: #fce4ec;
+        --grad-via: #f8ccda;
+        --grad-to: #f5aab8;
+        --accent-bg: rgba(255,36,66,0.08);
+      }
+      [data-platform="douyin"] {
+        --primary: #161823;
+        --grad-from: #c8e4e3;
+        --grad-via: #a8d8d6;
+        --grad-to: #7ecac8;
+        --accent-bg: rgba(37,244,238,0.10);
+      }
+      [data-platform="youtube"] {
+        --primary: #ff0000;
+        --grad-from: #fce6e6;
+        --grad-via: #f8d0d0;
+        --grad-to: #f5b0b0;
+        --accent-bg: rgba(255,0,0,0.08);
+      }
+      [data-platform="twitter"] {
+        --primary: #000000;
+        --grad-from: #eeeeee;
+        --grad-via: #d8d8d8;
+        --grad-to: #c0c0c0;
+        --accent-bg: rgba(0,0,0,0.06);
+      }
+      [data-platform="kuaishou"] {
+        --primary: #ff4906;
+        --grad-from: #fcece0;
+        --grad-via: #f8dac8;
+        --grad-to: #f5c0a0;
+        --accent-bg: rgba(255,73,6,0.08);
+      }
+      [data-platform="acfun"] {
+        --primary: #fd4c5d;
+        --grad-from: #fce6e9;
+        --grad-via: #f8d0d5;
+        --grad-to: #f5b0b8;
+        --accent-bg: rgba(253,76,93,0.08);
+      }
+      [data-platform="tiktok"] {
+        --primary: #010101;
+        --grad-from: #c8e4e3;
+        --grad-via: #a8d8d6;
+        --grad-to: #7ecac8;
+        --accent-bg: rgba(37,244,238,0.10);
+      }
+      [data-platform="nga"] {
+        --primary: #816b45;
+        --grad-from: #f4f0e8;
+        --grad-via: #ebe3d4;
+        --grad-to: #e0d5c0;
+        --accent-bg: rgba(129,107,69,0.08);
+      }
+
+      /* ──────── Reset ──────── */
+      * { box-sizing: border-box; margin: 0; padding: 0; }
 
       body {
-        font-family: "Inter", "Noto Sans SC", system-ui, -apple-system, sans-serif;
-        background-color: var(--bg-color);
-        /* Subtle mesh gradient background */
-        background-image: 
-          radial-gradient(at 0% 0%, hsla(253,16%,7%,1) 0, transparent 50%), 
-          radial-gradient(at 50% 0%, hsla(225,39%,30%,1) 0, transparent 50%), 
-          radial-gradient(at 100% 0%, hsla(339,49%,30%,1) 0, transparent 50%);
-        background-image: 
-          radial-gradient(at 40% 20%, hsla(28,100%,74%,1) 0px, transparent 50%),
-          radial-gradient(at 80% 0%, hsla(189,100%,56%,1) 0px, transparent 50%),
-          radial-gradient(at 0% 50%, hsla(355,100%,93%,1) 0px, transparent 50%);
-        background-size: 100% 100%;
-        background-attachment: fixed;
-        
+        font-family: {% if result.font_uri %}'HYSongYunLangHei', {% endif %}"Noto Sans SC", "PingFang SC", "Microsoft YaHei", system-ui, sans-serif;
         width: 800px;
-        padding: 60px;
         min-height: 100vh;
+        padding: 24px;
+        background: linear-gradient(160deg, var(--grad-from) 0%, var(--grad-via) 50%, var(--grad-to) 100%);
         display: flex;
         justify-content: center;
         align-items: flex-start;
         -webkit-font-smoothing: antialiased;
       }
 
+      /* ──────── 主卡片 ──────── */
       .card {
-        background-color: rgba(255, 255, 255, 0.95);
-        backdrop-filter: blur(12px);
-        border-radius: var(--radius-2xl);
-        box-shadow: var(--shadow-xl);
-        padding: 40px;
+        width: 100%;
+        background: var(--card-bg);
+        backdrop-filter: blur(40px) saturate(1.6);
+        -webkit-backdrop-filter: blur(40px) saturate(1.6);
+        border: 1.5px solid rgba(255,255,255,0.55);
+        border-radius: var(--radius-card);
+        box-shadow: var(--shadow-card), inset 0 1px 0 rgba(255,255,255,0.4);
+        padding: 24px;
         display: flex;
         flex-direction: column;
-        gap: 24px;
-        width: 100%;
-        position: relative;
-        border: 1px solid rgba(255, 255, 255, 0.5);
+        gap: 14px;
+        overflow: hidden;
       }
 
-      /* Header */
+      /* ──────── Header ──────── */
       .header {
         display: flex;
         align-items: center;
-        gap: 16px;
+        gap: 14px;
         position: relative;
       }
 
@@ -86,82 +148,185 @@
         height: 64px;
         border-radius: 50%;
         object-fit: cover;
-        border: 4px solid rgba(255, 255, 255, 0.8);
-        box-shadow: var(--shadow-md);
+        flex-shrink: 0;
+        border: 3px solid rgba(255,255,255,0.7);
+        box-shadow: 0 2px 10px rgba(0,0,0,0.10);
       }
 
       .user-info {
         display: flex;
         flex-direction: column;
         gap: 4px;
+        min-width: 0;
       }
 
       .username {
         font-size: 20px;
         font-weight: 700;
         color: var(--text-primary);
-        line-height: 1.2;
-        letter-spacing: -0.02em;
+        line-height: 1.3;
+        display: inline-flex;
+        align-items: center;
+        gap: 8px;
+        overflow: hidden;
       }
 
       .time {
-        font-size: 14px;
+        font-size: 16px;
         color: var(--text-secondary);
-        font-weight: 500;
-        display: flex;
-        align-items: center;
-        gap: 6px;
-      }
-      
-      .time::before {
-        content: "";
-        display: block;
-        width: 6px;
-        height: 6px;
-        border-radius: 50%;
-        background-color: var(--accent-color);
-        opacity: 0.5;
+        font-weight: 400;
       }
 
       .platform-logo {
         position: absolute;
         right: 0;
-        top: 0;
-        height: 28px;
+        top: 50%;
+        transform: translateY(-50%);
+        height: 30px;
         width: auto;
+        opacity: 0.8;
       }
 
-      /* Content */
+      /* ──────── 卡片包裹层 ──────── */
+      .card-wrapper {
+        position: relative;
+        width: 100%;
+      }
+
+      /* 有标签时，卡片左上角取消圆角 */
+      .card-wrapper.has-badge > .card {
+        border-top-left-radius: 0;
+      }
+
+      /* ──────── 内容类型标签（Tab 样式） ──────── */
+      .content-type-badge {
+        display: inline-flex;
+        align-items: center;
+        gap: 4px;
+        padding: 3px 10px;
+        border-radius: 8px 8px 0 0;
+        font-size: 18px;
+        font-weight: 400;
+        color: var(--primary);
+        background: var(--card-bg);
+        backdrop-filter: blur(40px) saturate(1.6);
+        -webkit-backdrop-filter: blur(40px) saturate(1.6);
+        border: 1.5px solid rgba(255,255,255,0.55);
+        border-bottom: none;
+        letter-spacing: 0.03em;
+        line-height: 1.4;
+        position: relative;
+        z-index: 5;
+      }
+
+      .content-type-badge .badge-icon {
+        display: inline-flex;
+        align-items: center;
+        width: 1em;
+        height: 1em;
+      }
+
+      .content-type-badge .badge-icon svg {
+        width: 100%;
+        height: 100%;
+        fill: var(--primary);
+      }
+
+      /* ──────── Content ──────── */
       .content-body {
         display: flex;
         flex-direction: column;
-        gap: 20px;
+        gap: 12px;
       }
 
       .title {
-        font-size: 22px;
+        font-size: 26px;
         font-weight: 800;
         color: var(--text-primary);
         line-height: 1.4;
-        letter-spacing: -0.02em;
+        letter-spacing: -0.01em;
       }
 
       .text {
-        font-size: 17px;
+        font-size: 18px;
         color: var(--text-primary);
         line-height: 1.75;
         white-space: pre-wrap;
         word-wrap: break-word;
-        font-weight: 400;
       }
 
-      /* Images */
+      /* ──────── 视频封面 ──────── */
+      .cover-wrapper {
+        position: relative;
+        width: 100%;
+        border-radius: var(--radius-img);
+        overflow: hidden;
+        border: 3px solid rgba(255,255,255,0.7);
+        box-shadow: 0 4px 16px rgba(0,0,0,0.12);
+      }
+
+      .cover-wrapper img.cover-img {
+        width: 100%;
+        height: auto;
+        display: block;
+        max-height: 450px;
+        object-fit: cover;
+      }
+
+      .cover-overlay {
+        position: absolute;
+        bottom: 0;
+        left: 0;
+        right: 0;
+        padding: 12px;
+        background: linear-gradient(transparent, rgba(0,0,0,0.5));
+        display: flex;
+        justify-content: flex-end;
+        align-items: flex-end;
+      }
+
+      .duration-badge {
+        padding: 3px 10px;
+        border-radius: 6px;
+        background: rgba(0,0,0,0.65);
+        color: white;
+        font-size: 13px;
+        font-weight: 600;
+        font-variant-numeric: tabular-nums;
+      }
+
+      /* ──────── 播放按钮 ──────── */
+      .play-button {
+        position: absolute;
+        top: 50%;
+        left: 50%;
+        transform: translate(-50%, -50%);
+        width: 72px;
+        height: 72px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        background: rgba(255, 255, 255, 0.25);
+        border: 2px solid rgba(255,255,255,0.4);
+        border-radius: 50%;
+        pointer-events: none;
+        backdrop-filter: blur(12px);
+        box-shadow: 0 4px 16px rgba(0,0,0,0.2);
+      }
+
+      .play-button img {
+        width: 50%;
+        height: 50%;
+        object-fit: contain;
+      }
+
+      /* ──────── 图片网格 ──────── */
       .image-container {
         width: 100%;
-        border-radius: var(--radius-xl);
+        border-radius: var(--radius-img);
         overflow: hidden;
-        box-shadow: var(--shadow-sm);
-        border: 1px solid rgba(0,0,0,0.04);
+        border: 3px solid rgba(255,255,255,0.7);
+        box-shadow: 0 4px 16px rgba(0,0,0,0.12);
       }
 
       .single-image {
@@ -172,141 +337,154 @@
 
       .image-grid {
         display: grid;
-        gap: 8px;
+        gap: 4px;
         width: 100%;
-        border-radius: var(--radius-xl);
+        border-radius: var(--radius-img);
         overflow: hidden;
+        border: 3px solid rgba(255,255,255,0.7);
+        box-shadow: 0 4px 16px rgba(0,0,0,0.12);
       }
 
-      .image-grid.cols-1 { grid-template-columns: 1fr; }
       .image-grid.cols-2 { grid-template-columns: repeat(2, 1fr); }
       .image-grid.cols-3 { grid-template-columns: repeat(3, 1fr); }
 
       .grid-item {
         position: relative;
         padding-bottom: 100%;
-        background-color: #f1f5f9;
+        background-color: var(--repost-bg);
         overflow: hidden;
+        border-radius: var(--radius-sm);
       }
 
       .grid-item img {
         position: absolute;
-        top: 0;
-        left: 0;
-        width: 100%;
-        height: 100%;
+        top: 0; left: 0;
+        width: 100%; height: 100%;
         object-fit: cover;
-        transition: transform 0.5s ease;
       }
 
       .more-count {
         position: absolute;
-        top: 0;
-        left: 0;
-        width: 100%;
-        height: 100%;
-        background-color: rgba(15, 23, 42, 0.6);
-        backdrop-filter: blur(4px);
+        top: 0; left: 0;
+        width: 100%; height: 100%;
+        background: rgba(0,0,0,0.45);
         color: white;
         display: flex;
         align-items: center;
         justify-content: center;
-        font-size: 32px;
-        font-weight: 600;
-        letter-spacing: -0.02em;
+        font-size: 28px;
+        font-weight: 700;
       }
 
-      /* Repost */
-      .card.repost {
-        background-color: var(--repost-bg);
-        box-shadow: none;
-        border: none;
-        border-radius: 4px var(--radius-lg) var(--radius-lg) 4px;
-        padding: 24px;
-        margin-top: 8px;
-      }
-      
-      .card.repost .header {
-        margin-bottom: 8px;
-      }
-      
-      .card.repost .avatar {
-        width: 40px;
-        height: 40px;
-        border-width: 2px;
-      }
-      
-      .card.repost .username {
-        font-size: 16px;
-      }
-      
-      .card.repost .text {
-        font-size: 15px;
-      }
-
-      /* Graphics Content */
+      /* ──────── 图文 ──────── */
       .graphics-item {
         display: flex;
         flex-direction: column;
-        gap: 12px;
-        padding: 20px;
-        background-color: #f8fafc;
-        border-radius: var(--radius-xl);
-        border: 1px solid var(--border-color);
+        gap: 8px;
+        padding: 14px;
+        background: var(--accent-bg);
+        border-radius: var(--radius-img);
       }
 
       .graphics-alt {
         font-size: 13px;
         color: var(--text-secondary);
         text-align: center;
-        margin-top: 8px;
         font-style: italic;
       }
 
-      /* Footer */
-      .footer {
-        margin-top: 12px;
-        padding-top: 24px;
-        border-top: 1px solid var(--border-color);
-        display: flex;
-        justify-content: flex-end;
-        align-items: center;
-        font-size: 13px;
-        color: var(--text-secondary);
-        font-weight: 500;
+      /* ──────── 转发 / Repost ──────── */
+      .card.repost {
+        background: linear-gradient(
+          135deg,
+          var(--accent-bg) 0%,
+          rgba(255,255,255,0.35) 50%,
+          var(--accent-bg) 100%
+        );
+        backdrop-filter: blur(32px) saturate(1.5);
+        -webkit-backdrop-filter: blur(32px) saturate(1.5);
+        box-shadow: -1px -1px 4px rgba(0,0,0,0.02), 4px 6px 16px rgba(0,0,0,0.08), 8px 10px 32px rgba(0,0,0,0.06);
+        border: 1px solid rgba(255,255,255,0.40);
+        border-left: 3.5px solid var(--primary);
+        border-radius: var(--radius-img);
+        padding: 18px;
+        gap: 12px;
+        overflow: hidden;
       }
-      
-      .footer-brand {
-        font-weight: 600;
-        color: var(--text-primary);
-        opacity: 0.4;
-        text-transform: uppercase;
-        letter-spacing: 0.05em;
+
+      .card.repost .avatar {
+        width: 44px;
+        height: 44px;
+        border-width: 2px;
+      }
+
+      .card.repost .username { font-size: 17px; }
+      .card.repost .time { font-size: 13px; }
+      .card.repost .title { font-size: 19px; }
+      .card.repost .text { font-size: 14px; line-height: 1.7; }
+
+      /* ──────── AI 总结面板 ──────── */
+      .ai-summary {
+        padding: 14px 18px;
+        border-radius: var(--radius-img);
+        background: var(--accent-bg);
+        backdrop-filter: blur(12px);
+        -webkit-backdrop-filter: blur(12px);
+        border: 1px solid rgba(255,255,255,0.25);
+        display: flex;
+        flex-direction: column;
+        gap: 8px;
+      }
+
+      .ai-summary-label {
+        font-size: 12px;
+        font-weight: 700;
+        color: var(--primary);
+        letter-spacing: 0.03em;
+        display: flex;
+        align-items: center;
+        gap: 5px;
+      }
+
+      .ai-summary-label::before {
+        content: '✦';
         font-size: 11px;
       }
 
-      .extra-info {
-        background: #f1f5f9;
-        padding: 6px 16px;
-        border-radius: 999px;
-        font-variant-numeric: tabular-nums;
+      .ai-summary-text {
+        font-size: 14px;
         color: var(--text-secondary);
-        font-size: 12px;
-        font-weight: 600;
+        line-height: 1.75;
+        white-space: pre-wrap;
+        word-wrap: break-word;
       }
     </style>
   </head>
-  <body>
+  <body data-platform="{{ result.platform.name if result.platform else '' | safe }}">
+    {% autoescape true %}
     {% macro render_card(result, is_repost=False) %}
+    <div class="{% if not is_repost %}card-wrapper{% if result.content_type %} has-badge{% endif %}{% endif %}">
+      {% if not is_repost and result.content_type %}
+      <span class="content-type-badge">
+        <span class="badge-icon">
+          {% if result.content_type == '视频' %}
+          <svg viewBox="0 0 24 24"><path d="M4 4h16a2 2 0 0 1 2 2v12a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2zm0 2v12h16V6H4zm6 2.5l6 3.5-6 3.5v-7z"/></svg>
+          {% elif result.content_type == '图文' %}
+          <svg viewBox="0 0 24 24"><path d="M4 3h16a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2zm0 2v14h16V5H4zm2 2h5v5H6V7zm7 0h5v2h-5V7zm0 4h5v2h-5v-2zM6 14h12v2H6v-2z"/></svg>
+          {% else %}
+          <svg viewBox="0 0 24 24"><path d="M5 3h14a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2zm0 2v14h14V5H5zm2 2h10v2H7V7zm0 4h10v2H7v-2zm0 4h6v2H7v-2z"/></svg>
+          {% endif %}
+        </span>
+        {{ result.content_type }}
+      </span>
+      {% endif %}
     <div class="card {% if is_repost %}repost{% endif %}">
-      {# Header #} {% if result.author %}
+
+      {# ── Header ── #}
+      {% if result.author %}
       <div class="header">
         {% if result.author.avatar_path %}
-        <img
-          src="{{ result.author.avatar_path }}"
-          class="avatar"
-          alt="avatar"
-        />
+        <img src="{{ result.author.avatar_path | safe }}" class="avatar" alt="avatar" />
         {% endif %}
         <div class="user-info">
           <div class="username">{{ result.author.name }}</div>
@@ -314,81 +492,112 @@
           <div class="time">{{ result.formartted_datetime }}</div>
           {% endif %}
         </div>
-        
-        {# Platform Logo #}
         {% if not is_repost and result.platform and result.platform.logo_path %}
-        <img src="{{ result.platform.logo_path }}" class="platform-logo" alt="{{ result.platform.display_name }}">
+        <img src="{{ result.platform.logo_path | safe }}" class="platform-logo" alt="{{ result.platform.display_name }}" />
         {% endif %}
       </div>
       {% endif %}
 
       <div class="content-body">
-        {# Title #} {% if result.title %}
-        <div class="title">{{ result.title }}</div>
-        {% endif %} 
-        
-        {# Text #} {% if result.text %}
-        <div class="text">{{ result.text }}</div>
-        {% endif %} 
-        
-        {# Images / Cover #} {% if result.cover_path %}
-        <div class="image-container">
-          <img src="{{ result.cover_path }}" class="single-image" alt="cover" />
+        {# ── 视频封面（显示在标题前，匹配 CommonRenderer 布局） ── #}
+        {% if result.video_contents %}
+        {% set vc = result.video_contents[0] %}
+        {% if vc.cover_path %}
+        <div class="cover-wrapper">
+          <img src="{{ vc.cover_path | safe }}" class="cover-img" alt="cover" />
+          {% if result.play_icon_uri %}
+          <div class="play-button">
+            <img src="{{ result.play_icon_uri | safe }}" alt="play" />
+          </div>
+          {% endif %}
+          {% if vc.duration %}
+          <div class="cover-overlay">
+            <div class="duration-badge">{{ vc.duration }}</div>
+          </div>
+          {% endif %}
         </div>
-        {% elif result.img_contents %} {% set imgs = result.img_contents %} {%
-        set count = imgs|length %} {% if count == 1 %}
-        <div class="image-container">
-          <img src="{{ imgs[0].path }}" class="single-image" alt="image" />
-        </div>
-        {% else %} {% set cols = 3 %} {% if count == 2 or count == 4 %} {% set
-        cols = 2 %} {% endif %}
+        {% endif %}
+        {% endif %}
 
+        {# ── Title ── #}
+        {% if result.title %}
+        <div class="title">{{ result.title }}</div>
+        {% endif %}
+
+        {# ── Text ── #}
+        {% if result.text %}
+        <div class="text">{{ result.text }}</div>
+        {% endif %}
+
+        {# ── 非视频媒体 ── #}
+        {% if not result.video_contents %}
+
+        {# ── Cover (fallback, non-video) ── #}
+        {% if result.cover_path %}
+        <div class="image-container">
+          <img src="{{ result.cover_path | safe }}" class="single-image" alt="cover" />
+        </div>
+
+        {# ── Image Grid ── #}
+        {% elif result.img_contents %}
+        {% set imgs = result.img_contents %}
+        {% set count = imgs|length %}
+        {% if count == 1 %}
+        <div class="image-container">
+          <img src="{{ imgs[0].path | safe }}" class="single-image" alt="image" />
+        </div>
+        {% else %}
+        {% set cols = 3 %}
+        {% if count == 2 or count == 4 %}{% set cols = 2 %}{% endif %}
         <div class="image-grid cols-{{ cols }}">
           {% for img in imgs[:9] %}
           <div class="grid-item">
-            <img src="{{ img.path }}" alt="image" />
+            <img src="{{ img.path | safe }}" alt="image" />
             {% if loop.last and count > 9 %}
             <div class="more-count">+{{ count - 9 }}</div>
             {% endif %}
           </div>
           {% endfor %}
         </div>
-        {% endif %} 
-        
-        {# Graphics #}
-        {% elif result.graphics_contents %} {% for graphics in
-        result.graphics_contents %}
+        {% endif %}
+
+        {# ── Graphics ── #}
+        {% elif result.graphics_contents %}
+        {% for graphics in result.graphics_contents %}
         <div class="graphics-item">
           {% if graphics.text %}
           <div class="text">{{ graphics.text }}</div>
           {% endif %}
           <div class="image-container">
-            <img
-              src="{{ graphics.path }}"
-              class="single-image"
-              alt="graphics"
-            />
+            <img src="{{ graphics.path | safe }}" class="single-image" alt="graphics" />
           </div>
           {% if graphics.alt %}
           <div class="graphics-alt">{{ graphics.alt }}</div>
           {% endif %}
         </div>
-        {% endfor %} {% endif %} 
-        
-        {# Repost #} {% if result.repost %} {{
-        render_card(result.repost, is_repost=True) }} {% endif %}
+        {% endfor %}
+        {% endif %}
+
+        {% endif %}
+
+        {# ── Repost ── #}
+        {% if result.repost %}
+        {{ render_card(result.repost, is_repost=True) }}
+        {% endif %}
       </div>
 
-        {# Footer / Extra #}
-        {% if not is_repost %}
-        <div class="footer">
-
-            {% if result.extra_info %}
-            <div class="extra-info">{{ result.extra_info }}</div>
-            {% endif %}
-        </div>
-        {% endif %}
+      {# ── AI 总结 ── #}
+      {% if not is_repost and result.extra_info %}
+      <div class="ai-summary">
+        <div class="ai-summary-label">AI 总结</div>
+        <div class="ai-summary-text">{{ result.extra_info }}</div>
+      </div>
+      {% endif %}
     </div>
-    {% endmacro %} {{ render_card(result) }}
+    {% if not is_repost %}</div>{% endif %}
+    {% endmacro %}
+
+    {{ render_card(result) }}
+    {% endautoescape %}
   </body>
 </html>

--- a/src/nonebot_plugin_parser/renders/templates/card.html.jinja
+++ b/src/nonebot_plugin_parser/renders/templates/card.html.jinja
@@ -499,7 +499,12 @@
       {% endif %}
 
       <div class="content-body">
-        {# ── 视频封面（显示在标题前，匹配 CommonRenderer 布局） ── #}
+        {# ── 动态类型：文字显示在封面上方 ── #}
+        {% if result.content_type == '动态' and result.text %}
+        <div class="text">{{ result.text }}</div>
+        {% endif %}
+
+        {# ── 视频封面 ── #}
         {% if result.video_contents %}
         {% set vc = result.video_contents[0] %}
         {% if vc.cover_path %}
@@ -524,8 +529,8 @@
         <div class="title">{{ result.title }}</div>
         {% endif %}
 
-        {# ── Text ── #}
-        {% if result.text %}
+        {# ── Text（非动态类型） ── #}
+        {% if result.content_type != '动态' and result.text %}
         <div class="text">{{ result.text }}</div>
         {% endif %}
 

--- a/src/nonebot_plugin_parser/renders/templates/card.html.jinja
+++ b/src/nonebot_plugin_parser/renders/templates/card.html.jinja
@@ -110,7 +110,6 @@
       body {
         font-family: {% if result.font_uri %}'HYSongYunLangHei', {% endif %}"Noto Sans SC", "PingFang SC", "Microsoft YaHei", system-ui, sans-serif;
         width: 800px;
-        min-height: 100vh;
         padding: 24px;
         background: linear-gradient(160deg, var(--grad-from) 0%, var(--grad-via) 50%, var(--grad-to) 100%);
         display: flex;
@@ -149,7 +148,7 @@
         border-radius: 50%;
         object-fit: cover;
         flex-shrink: 0;
-        border: 3px solid rgba(255,255,255,0.7);
+        border: 1.5px solid rgba(255,255,255,0.7);
         box-shadow: 0 2px 10px rgba(0,0,0,0.10);
       }
 
@@ -261,8 +260,8 @@
         width: 100%;
         border-radius: var(--radius-img);
         overflow: hidden;
-        border: 3px solid rgba(255,255,255,0.7);
-        box-shadow: 0 4px 16px rgba(0,0,0,0.12);
+        border: 1.5px solid rgba(255,255,255,0.7);
+        box-shadow: none;
       }
 
       .cover-wrapper img.cover-img {
@@ -307,7 +306,7 @@
         align-items: center;
         justify-content: center;
         background: rgba(255, 255, 255, 0.25);
-        border: 2px solid rgba(255,255,255,0.4);
+        border: 1.5px solid rgba(255,255,255,0.4);
         border-radius: 50%;
         pointer-events: none;
         backdrop-filter: blur(12px);
@@ -325,8 +324,8 @@
         width: 100%;
         border-radius: var(--radius-img);
         overflow: hidden;
-        border: 3px solid rgba(255,255,255,0.7);
-        box-shadow: 0 4px 16px rgba(0,0,0,0.12);
+        border: 1.5px solid rgba(255,255,255,0.7);
+        box-shadow: none;
       }
 
       .single-image {
@@ -337,12 +336,8 @@
 
       .image-grid {
         display: grid;
-        gap: 4px;
+        gap: 8px;
         width: 100%;
-        border-radius: var(--radius-img);
-        overflow: hidden;
-        border: 3px solid rgba(255,255,255,0.7);
-        box-shadow: 0 4px 16px rgba(0,0,0,0.12);
       }
 
       .image-grid.cols-2 { grid-template-columns: repeat(2, 1fr); }
@@ -353,7 +348,9 @@
         padding-bottom: 100%;
         background-color: var(--repost-bg);
         overflow: hidden;
-        border-radius: var(--radius-sm);
+        border-radius: var(--radius-img);
+        border: 1.5px solid rgba(255,255,255,0.7);
+        box-shadow: none;
       }
 
       .grid-item img {
@@ -404,7 +401,7 @@
         backdrop-filter: blur(32px) saturate(1.5);
         -webkit-backdrop-filter: blur(32px) saturate(1.5);
         box-shadow: -1px -1px 4px rgba(0,0,0,0.02), 4px 6px 16px rgba(0,0,0,0.08), 8px 10px 32px rgba(0,0,0,0.06);
-        border: 1px solid rgba(255,255,255,0.40);
+        border: none;
         border-left: 3.5px solid var(--primary);
         border-radius: var(--radius-img);
         padding: 18px;
@@ -415,7 +412,7 @@
       .card.repost .avatar {
         width: 44px;
         height: 44px;
-        border-width: 2px;
+        border-width: 1.5px;
       }
 
       .card.repost .username { font-size: 17px; }
@@ -537,14 +534,8 @@
         {# ── 非视频媒体 ── #}
         {% if not result.video_contents %}
 
-        {# ── Cover (fallback, non-video) ── #}
-        {% if result.cover_path %}
-        <div class="image-container">
-          <img src="{{ result.cover_path | safe }}" class="single-image" alt="cover" />
-        </div>
-
         {# ── Image Grid ── #}
-        {% elif result.img_contents %}
+        {% if result.img_contents %}
         {% set imgs = result.img_contents %}
         {% set count = imgs|length %}
         {% if count == 1 %}

--- a/src/nonebot_plugin_parser/renders/templates/card.html.jinja
+++ b/src/nonebot_plugin_parser/renders/templates/card.html.jinja
@@ -520,7 +520,7 @@
           {% endif %}
           {% if vc.duration %}
           <div class="cover-overlay">
-            <div class="duration-badge">{{ vc.duration }}</div>
+            <div class="duration-badge">{{ vc.display_duration }}</div>
           </div>
           {% endif %}
         </div>

--- a/src/nonebot_plugin_parser/renders/templates/card.html.jinja
+++ b/src/nonebot_plugin_parser/renders/templates/card.html.jinja
@@ -7,7 +7,7 @@
     <style>
       {% if result.font_uri %}
       @font-face {
-        font-family: 'HYSongYunLangHei';
+        font-family: 'CustomFont';
         src: url('{{ result.font_uri | safe }}');
       }
       {% endif %}
@@ -108,7 +108,7 @@
       * { box-sizing: border-box; margin: 0; padding: 0; }
 
       body {
-        font-family: {% if result.font_uri %}'HYSongYunLangHei', {% endif %}"Noto Sans SC", "PingFang SC", "Microsoft YaHei", system-ui, sans-serif;
+        font-family: {% if result.font_uri %}'CustomFont', {% endif %}"Noto Sans SC", "PingFang SC", "Microsoft YaHei", system-ui, sans-serif;
         width: 800px;
         padding: 24px;
         background: linear-gradient(160deg, var(--grad-from) 0%, var(--grad-via) 50%, var(--grad-to) 100%);

--- a/src/nonebot_plugin_parser/utils.py
+++ b/src/nonebot_plugin_parser/utils.py
@@ -149,7 +149,7 @@ def fmt_size(file_path: Path) -> str:
     return f"大小: {file_path.stat().st_size / 1024 / 1024:.2f} MB"
 
 
-def fmt_duration(duration: float | int) -> str:
+def fmt_duration(duration: float) -> str:
     """格式化媒体时长，超过 1 小时后显示为 h:mm:ss。"""
     total_seconds = max(int(duration), 0)
     hours, remainder = divmod(total_seconds, 3600)

--- a/src/nonebot_plugin_parser/utils.py
+++ b/src/nonebot_plugin_parser/utils.py
@@ -149,6 +149,17 @@ def fmt_size(file_path: Path) -> str:
     return f"大小: {file_path.stat().st_size / 1024 / 1024:.2f} MB"
 
 
+def fmt_duration(duration: float | int) -> str:
+    """格式化媒体时长，超过 1 小时后显示为 h:mm:ss。"""
+    total_seconds = max(int(duration), 0)
+    hours, remainder = divmod(total_seconds, 3600)
+    minutes, seconds = divmod(remainder, 60)
+
+    if hours:
+        return f"{hours}:{minutes:02d}:{seconds:02d}"
+    return f"{minutes}:{seconds:02d}"
+
+
 def generate_file_name(url: str, default_suffix: str = "") -> str:
     """根据 url 生成文件名"""
 

--- a/tests/others/test_utils.py
+++ b/tests/others/test_utils.py
@@ -16,6 +16,15 @@ def test_keep_zh_en_num():
     assert keep_zh_en_num("12#¥%……*3ab#*#@c测#**@@试") == "123abc测试"
 
 
+def test_fmt_duration():
+    from nonebot_plugin_parser.utils import fmt_duration
+
+    assert fmt_duration(59) == "0:59"
+    assert fmt_duration(3599) == "59:59"
+    assert fmt_duration(3600) == "1:00:00"
+    assert fmt_duration(3661) == "1:01:01"
+
+
 async def test_clean_plugin_cache():
     from nonebot_plugin_parser import clean_plugin_cache
 

--- a/tests/parsers/test_kuaishou.py
+++ b/tests/parsers/test_kuaishou.py
@@ -10,6 +10,7 @@ async def test_parse():
     """测试快手视频解析"""
     from nonebot_plugin_parser.utils import fmt_size
     from nonebot_plugin_parser.parsers import KuaiShouParser
+    from nonebot_plugin_parser.exception import IgnoreException
 
     parser = KuaiShouParser()
 
@@ -42,7 +43,11 @@ async def test_parse():
         # 检查图片
         if pic_paths := parse_result.img_contents:
             for pic_path in pic_paths:
-                path = await pic_path.get_path()
+                try:
+                    path = await pic_path.get_path()
+                except IgnoreException:
+                    continue
+
                 assert path.exists()
                 logger.debug(f"{url} | 图片下载完成: {path}, 图片{fmt_size(path)}")
             assert len(pic_paths) > 0, "图片下载数量为0"


### PR DESCRIPTION
设计了一套渲染模板并为每个平台适配了一套主题色，此外修复了bilibili转发动态无法正常显示的问题，详见commit title

示例：
<img width="1280" height="2142" alt="34da753b27edefd52fc904c15d0b7927_720" src="https://github.com/user-attachments/assets/8fb7455a-345a-4f80-8b8f-5c3aebd70110" />
<img width="1280" height="1259" alt="01bc811c1898e38d3d703f7469a538e8_720" src="https://github.com/user-attachments/assets/9bc2a094-cd93-40db-8e07-856e31327ed1" />
<img width="1600" height="1886" alt="ad306003cd083813ba32648baa751615" src="https://github.com/user-attachments/assets/48e379a6-bde2-44fe-b2b1-6384f9fe7300" />
<img width="1280" height="1102" alt="0289f3277f20c3e9deac9eba027f2ad1_720" src="https://github.com/user-attachments/assets/0ffa23fe-3717-4998-8af5-46310fbb7269" />
<img width="1280" height="1667" alt="bedc19f6ef5bdc4d830ac781e8af977c_720" src="https://github.com/user-attachments/assets/064b3dd8-1d35-4a39-8f26-bf2bc533e153" />
<img width="1600" height="1466" alt="c3bc206f0b3411565507dbed66c3b802" src="https://github.com/user-attachments/assets/6e33cd72-8d03-4adb-90c4-94f790d7ccde" />
