### PR TITLE
fix(config): 修复 parser_bili_video_codes 环境变量 Pydantic 校验失败问题

### DIFF
--- a/src/nonebot_plugin_parser/config.py
+++ b/src/nonebot_plugin_parser/config.py
@@ -1,6 +1,8 @@
 from pathlib import Path
+from typing import Any
 
 from nonebot import logger, require, get_driver, get_plugin_config
+from nonebot.compat import field_validator
 from apilmoji import ELK_SH_CDN, EmojiStyle
 from pydantic import BaseModel
 from bilibili_api.video import VideoCodecs, VideoQuality
@@ -58,6 +60,32 @@ class Config(BaseModel):
     """Pilmoji 表情样式"""
     parser_group_blacklist_enabled: bool = True
     """是否启用群组黑名单模式(默认启用，即所有群聊的解析都是开启的)"""
+
+    @field_validator("parser_bili_video_codes", mode="before")
+    @classmethod
+    def _validate_bili_video_codes(cls, v: Any) -> Any:
+        """兼容转换 B站视频编码配置"""
+        if isinstance(v, str):
+            import json
+
+            try:
+                v = json.loads(v)
+            except Exception:
+                v = [x.strip() for x in v.split(",")]
+        if isinstance(v, (list, tuple)):
+            codecs = []
+            for item in v:
+                if isinstance(item, VideoCodecs):
+                    codecs.append(item)
+                    continue
+                s = str(item).lower()
+                for c in VideoCodecs:
+                    val = c.value
+                    if s == c.name.lower() or (isinstance(val, tuple) and s in val) or val == s:
+                        codecs.append(c)
+                        break
+            return codecs
+        return v
 
     @property
     def nickname(self) -> str:


### PR DESCRIPTION
- **修复背景**：在配置 `parser_bili_video_codes` 环境变量（如 `["hev", "av01", "avc"]`）时，因 `bilibili_api` 中 `VideoCodecs` 枚举成员值为元组类型，导致 Pydantic 默认枚举校验报 ValidationError。
<img width="752" height="125" alt="image" src="https://github.com/user-attachments/assets/2b615caa-b797-4940-8c2e-55a59883c8a4" />

- **解决方案**：在 `Config` 模型中增加 `parser_bili_video_codes` 的前置字段校验器（`@field_validator(mode="before")`），支持将字符串列表、JSON 数组及逗号分隔字符串自动转换并映射至对应的 `VideoCodecs` 枚举成员。
- **影响范围**：仅影响 `config.py` 中 `parser_bili_video_codes` 配置项的反序列化与兼容解析。
- **测试验证**：已验证测试修改后插件正常工作。